### PR TITLE
[YUNIKORN-917] Update website to include YuniKorn Meetup contents

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,7 +93,7 @@ module.exports = {
             },
             {
               to: 'community/sessions',
-              label: 'Sessions and Demos',
+              label: 'Resources',
               position: 'left',
             },
           ]

--- a/src/pages/community/sessions.md
+++ b/src/pages/community/sessions.md
@@ -1,6 +1,6 @@
 ---
 id: sessions
-title: Sessions and Demos
+title: Resources
 ---
 
 <!--
@@ -22,36 +22,32 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-Conference Talks
+Upcoming Meetup
 ---
 
-<div className="col">
-  <h3>Cloud-Native Spark Scheduling with YuniKorn Scheduler</h3>
-  <iframe width="560"
-          height="315"
-          src="https://www.youtube.com/embed/ZA6aPZ9r9wA"
-          frameborder="0"
-          allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-  </iframe>
-</div>
+Upcoming Event:  **4:00pm - 5:00pm, PST**, Nov 18, 2021
 
+Past Conference Sessions
 ---
 
-<div className="col">
-  <h3>Energize multi-tenant Flink on K8s with YuniKorn</h3>
-  <iframe width="560"
-        height="315"
-        src="https://www.youtube.com/embed/NemFKL0kK9U"
-        frameborder="0"
-        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen>
-  </iframe>
-</div>
+- ApacheCon 2021: [Next Level Spark on Kubernetes with Apache YuniKorn (Incubating)](https://youtu.be/gOST-iT-hj8) :busts_in_silhouette: Weiwei Yang, Chaoran Yu
+- ApacheCon Asia 2021: [State Of The Union With Apache Yunikorn (Incubating) - Cloud Native Scheduler For Big Data Usecases
+  ](https://www.youtube.com/watch?v=c9UYxzqVMeg)  :busts_in_silhouette: Julia Kinga Marton, Sunil Govindan
+- Future of Data Meetup: [Apache YuniKorn: Cloud-native Resource Scheduling](https://www.youtube.com/watch?v=j-6ehu6GrwE) :busts_in_silhouette: Wangda Tan, Wilfred Spiegelenburg
+- ApacheCon 2020: [Integrate Apache Flink with Cloud Native Ecosystem](https://youtu.be/4hghJCuZk5M) :busts_in_silhouette: Yang Wang, Tao Yang
+- Spark+AI Summit 2020: [Cloud-Native Spark Scheduling with YuniKorn Scheduler](https://www.youtube.com/embed/ZA6aPZ9r9wA) :busts_in_silhouette: Gao Li, Weiwei Yang
+- Flink Forward 2020: [Energize multi-tenant Flink on K8s with YuniKorn](https://www.youtube.com/embed/NemFKL0kK9U) :busts_in_silhouette: Weiwei Yang, Wilfred Spiegelenburg
+
 
 Demo Videos
 ---
 
-- Subscribe to [YuniKorn Youtube Channel](https://www.youtube.com/channel/UCDSJ2z-lEZcjdK27tTj_hGw) to get notification about new demos!
+Please subscribe to [YuniKorn Youtube Channel](https://www.youtube.com/channel/UCDSJ2z-lEZcjdK27tTj_hGw) to get notification about new demos!
 - [Running YuniKorn on Kubernetes - a 12 minutes Hello-world demo](https://www.youtube.com/watch?v=cCHVFkbHIzo)
 - [YuniKorn configuration hot-refresh introduction](https://www.youtube.com/watch?v=3WOaxoPogDY)
 - [Yunikorn scheduling and volumes on Kubernetes](https://www.youtube.com/watch?v=XDrjOkMp3k4)
 - [Yunikorn placement rules for applications](https://www.youtube.com/watch?v=DfhJLMjaFH0)
+- [Federated K8s compute pools with YuniKorn](https://www.youtube.com/watch?v=l7Ydg_ZGZw0&t)
+
+If you are a YuniKorn evangelist, and you have public conference talks, demo recording that related to YuniKorn.
+Please submit a PR to extend this list!


### PR DESCRIPTION
Rework on the "community/Sessions and demos" section, include meetup info, and past events links. See the screenshot below. Once https://issues.apache.org/jira/browse/YUNIKORN-914 is done, I will submit a simple patch to include the meetup info in this page.
<img width="1345" alt="Resources___Apache_YuniKorn__Incubating_" src="https://user-images.githubusercontent.com/14214570/138826906-ec11c30b-ca24-48b2-b115-50f52882252a.png">
.