### PR TITLE
[YUNIKORN-1254] Update image version of node in the run command in the local_run.sh

### DIFF
--- a/local-build.sh
+++ b/local-build.sh
@@ -34,7 +34,7 @@ function clean() {
 function image_build() {
   # build local docker image
   cat <<EOF >.dockerfile.tmp
-FROM node:16.13.0
+FROM node:16.14
 ADD . /yunikorn-site
 WORKDIR /yunikorn-site
 EOF


### PR DESCRIPTION
# Problem description
There is a problem about dependency in the building step.
Update the version of node image in the `run` command.

# Issue type
- [x] Bug

# Apache jira link
https://issues.apache.org/jira/browse/YUNIKORN-1254

#  How to test
Run ./local-build.sh run and then visit the localhost:3000