### PR TITLE
[YUNIKORN-1293] Add custom redirects to the current version doc

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,6 +36,19 @@ module.exports = {
       },
     },
   },
+  plugins: [
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        redirects: [
+          {
+            to: '/docs/1.0.0',
+            from: '/docs/',
+          },
+        ],
+      },
+    ],
+  ],
   presets: [
     [
       '@docusaurus/preset-classic',

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.1",
+    "@docusaurus/plugin-client-redirects": "^2.0.1",
     "@docusaurus/preset-classic": "2.0.1",
     "@docusaurus/theme-search-algolia": "^2.0.1",
     "@mdx-js/react": "^1.5.8",


### PR DESCRIPTION
Docusaurus hides the version number in the URL for the latest versions, e.g right now our latest version is 1.0.0, but http://localhost:3000/docs/1.0.0 gives a 404. Ideally, we should make have an accessible URL for this version as well. This is in order to fix: https://github.com/apache/spark/pull/37622

