### PR TITLE
[YUNIKORN-1293] Revert the customized redirects

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -36,19 +36,6 @@ module.exports = {
       },
     },
   },
-  plugins: [
-    [
-      '@docusaurus/plugin-client-redirects',
-      {
-        redirects: [
-          {
-            to: '/docs/1.0.0',
-            from: '/docs/',
-          },
-        ],
-      },
-    ],
-  ],
   presets: [
     [
       '@docusaurus/preset-classic',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,8 +42,8 @@ module.exports = {
       {
         redirects: [
           {
-            to: '/docs/',
-            from: '/docs/1.0.0',
+            to: '/docs/1.0.0',
+            from: '/docs/',
           },
         ],
       },

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   },
   "dependencies": {
     "@docusaurus/core": "2.0.1",
-    "@docusaurus/plugin-client-redirects": "^2.0.1",
     "@docusaurus/preset-classic": "2.0.1",
     "@docusaurus/theme-search-algolia": "^2.0.1",
     "@mdx-js/react": "^1.5.8",


### PR DESCRIPTION
Since https://issues.apache.org/jira/browse/SPARK-40187 now has been solved, there is no reference to the 1.0 version doc. This customized redirect is no longer needed.