### PR TITLE
Add a missing newline in Tag Rule section

### DIFF
--- a/docs/user_guide/placement_rules.md
+++ b/docs/user_guide/placement_rules.md
@@ -261,6 +261,7 @@ Result: `root.last_resort`
 
 ### Tag Rule
 Name to be used in the configuration: *tag*
+
 Retrieves the queue name from the applications tags.
 The tag name that is checked for its value is configured in the rule using the `value`.
 Configuring a tag rule without a `value` set is an error, however an application does not have to have the tag set.


### PR DESCRIPTION
I think the newline is missing.

<img width="653" alt="image" src="https://user-images.githubusercontent.com/31306282/195788264-c8b6bdbc-cfbb-4d8e-92ae-f61aeb3b8989.png">

I add the newline.