### PR TITLE
[YUNIKORN-1299] kind docs

### DIFF
--- a/docs/developer_guide/build.md
+++ b/docs/developer_guide/build.md
@@ -73,7 +73,8 @@ For the deployment that uses a config map you need to set up the ConfigMap in ku
 How to deploy the scheduler with a ConfigMap is explained in the [scheduler configuration deployment](developer_guide/deployment.md) document.
 
 The image build command will first build the integrated executable and then create the docker image.
-Currently, there are some published docker images under [this docker hub repo](https://hub.docker.com/r/apache/yunikorn), you are free to fetch and use.
+If you want to use pre-build images based on a release please check [the docker hub repo](https://hub.docker.com/r/apache/yunikorn).
+
 The default image tags are not suitable for deployments to an accessible repository as it uses a hardcoded user and would push to Docker Hub with proper credentials.
 You *must* update the `TAG` variable in the `Makefile` to push to an accessible repository.
 When you update the image tag be aware that the deployment examples given will also need to be updated to reflect the same change.
@@ -84,8 +85,10 @@ The docker image built from previous step has embedded some important build info
 these info with docker `inspect` command.
 
 ```
-docker inspect apache/yunikorn:scheduler-latest
+docker inspect apache/yunikorn:scheduler-amd64-latest
 ```
+
+The `amd64` tag is dependent on your host architecture ie for Intel it would be amd64 and for MacM1, it would be arm64v1.
 
 This info includes git revisions (last commit SHA) for each component, to help you understand which version of the source code
 was shipped by this image. They are listed as docker image `labels`, such as
@@ -106,7 +109,7 @@ The dependencies in the projects are managed using [go modules](https://blog.gol
 Go Modules require at least Go version 1.11 to be installed on the development system.
 
 If you want to modify one of the projects locally and build with your local dependencies you will need to change the module file. 
-Changing dependencies uses mod `replace` directives as explained in the [Update dependencies](#Updating dependencies).
+Changing dependencies uses mod `replace` directives as explained in the [Update dependencies](#updating-dependencies).
 
 The YuniKorn project has four repositories three of those repositories have a dependency at the go level.
 These dependencies are part of the go modules and point to the github repositories.
@@ -159,13 +162,13 @@ Further details on the modules' wiki: [When should I use the 'replace' directive
 ## Build the web UI
 
 Example deployments reference the [YuniKorn web UI](https://github.com/apache/yunikorn-web). 
-The YuniKorn web UI has its own specific requirements for the build. The project has specific requirements for the build follow the steps in the README to prepare a development environment and build how to build the projects.
+The Yunikorn web project has specific requirements for the build follow the steps in the [README](https://github.com/apache/yunikorn-web/blob/master/README.md) to prepare a development environment and build the web UI.
 The scheduler is fully functional without the web UI. 
 
 ## Locally run the integrated scheduler
 
 When you have a local development environment setup you can run the scheduler in your local kubernetes environment.
-This has been tested in a Docker desktop with 'Docker for desktop' and Minikube. See the [environment setup guide](developer_guide/env_setup.md) for further details.
+This has been tested in a Docker desktop with 'Docker for desktop', Minikube and Kind. See the [environment setup guide](developer_guide/env_setup.md) for further details.
 
 ```
 make run

--- a/docs/developer_guide/deployment.md
+++ b/docs/developer_guide/deployment.md
@@ -33,11 +33,13 @@ Under project root of the `yunikorn-k8shim`, run the command to build an image u
 make image
 ```
 
-This command will build an image. The image will be tagged with a default version and image tag.
+This command will build an image. The image will be tagged with a default version, image tag and your build architecture. 
 
 **Note** the default build uses a hardcoded user and tag. You *must* update the `IMAGE_TAG` variable in the `Makefile` to push to an appropriate repository. 
 
 **Note** the latest yunikorn images in docker hub are not updated anymore due to ASF policy. Hence, you should build both scheduler image and web image locally before deploying them.
+
+**Note** the imaging tagging includes your build architecture. For intel, it would be amd64 and for MacM1, it would be arm64v1.  
 
 ## Setup RBAC for Scheduler
 

--- a/docs/developer_guide/env_setup.md
+++ b/docs/developer_guide/env_setup.md
@@ -22,8 +22,8 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-There are several ways to setup a local development environment for Kubernetes, the two most common ones are `Minikube` ([docs](https://kubernetes.io/docs/setup/minikube/)) and `docker-desktop`.
-`Minikube` provisions a local Kubernetes cluster on several Virtual Machines (via VirtualBox or something similar). `docker-desktop` on the other hand, sets up Kubernetes cluster in docker containers.
+There are several ways to setup a local development environment for Kubernetes, the three most common ones are `Minikube` ([docs](https://kubernetes.io/docs/setup/minikube/)), `docker-desktop` and `kind` ([kind](https://kind.sigs.k8s.io/))
+`Minikube` provisions a local Kubernetes cluster on several Virtual Machines (via VirtualBox or something similar). `docker-desktop` on the other hand, sets up Kubernetes cluster in docker containers.  `kind` provides lightweight Kubernetes clusters for Windows, Linux and Mac.  
 
 ## Local Kubernetes cluster using Docker Desktop
 
@@ -98,7 +98,7 @@ Check hypervisor Docker Desktop should have already installed HyperKit. In a ter
 
 ### Deploy and access the cluster
 After the installation is done you can start a new cluster.
-1. start the minikube cluster: `minikube start --kubernetes-version v1.14.2`
+1. start the minikube cluster: `minikube start --kubernetes-version v1.24.7`
 1. start the minikube dashboard: `minikube dashboard &`
 
 ### Build impact
@@ -108,6 +108,39 @@ Without setting the enviromnent minikube might not find the docker images when d
 1. in the terminal where you wll run the build execute: `eval $(minikube docker-env)`
 1. run the image build from the yunikorn-k8shim repository root: `make image`
 1. deploy the scheduler as per the normal instructions.
+
+## Local Kubernetes Cluster with Kind
+
+Kind (Kubernetes in Docker) is a lightweight tool for running lightweight Kubernetes environments.  It is very easy to test different Kubernetes versions with kind.  You can just select the kind image you want.
+
+### Installation
+
+If you have go installed, you can run `go install sigs.k8s.io/kind@latest`.
+
+Other ways can be found on the Kind [website](https://kind.sigs.k8s.io/docs/user/quick-start/#installation)
+
+To use Kind with Kubernetes 1.25, you will need to use kind@v0.15 or greater.  The release of kind does allow for particular versions of Kubernetes and you can get that information from the Kind release notes.
+### Using Kind
+
+To test a new version of Kubernetes, you can pull a corresponding image from kind's repo.
+
+Creating a v1.24.7 Kubernetes Cluster: `kind create cluster --name test --image kindest/node:v1.24.7`
+
+Deleting a kind cluster: `kind delete cluster --name test`
+
+### Loading your images
+
+In order to use a local image, you have to load your images into kind's registry.  If you run `make image`, you could use the following command to load your kind image.  This assumes AMD64 architecture.
+
+The scheduler, web-ui and admission-controller examples are below: 
+scheduler:
+`kind load docker-image apache/yunikorn:scheduler-amd64-latest`
+
+web: 
+`kind load docker-image apache/yunikorn:web-amd64-latest`
+
+admission-controller:
+`kind load docker-image apache/yunikorn:admission-amd64-latest`
 
 ## Debug code locally
 


### PR DESCRIPTION
This ticket addresses the following items in 1299:

- [x] Should add kind as a deployment option to the "Deploy to Kubernetes" page. Pointer can be added to the validate_cluster script as an example.
- [x] reference to "some published docker images under this docker hub repo", images are part of the release not just random images anymore
- [x] broken link under dependencies
as explained in the [Update dependencies](#Updating dependencies).
- [x] the web UI image can be build using the two stage docker not requiring any installs, should only point back to the repo readme for dev setup