### PR TITLE
[YUNIKORN-1421] Update the "Build and Run" page of the docs

### DIFF
--- a/docs/developer_guide/build.md
+++ b/docs/developer_guide/build.md
@@ -33,7 +33,7 @@ Read the [environment setup guide](developer_guide/env_setup.md) first to setup 
 ## Build YuniKorn for Kubernetes
 
 Prerequisite:
-- Go 1.16+
+- Golang, check [yunikorn-k8shim/.go_version](https://github.com/apache/yunikorn-k8shim/blob/master/.go_version) to see the version of Yunikorn request.
 
 You can build the scheduler for Kubernetes from [yunikorn-k8shim](https://github.com/apache/yunikorn-k8shim) project.
 The build procedure will build all components into a single executable that can be deployed and running on Kubernetes.

--- a/docs/developer_guide/build.md
+++ b/docs/developer_guide/build.md
@@ -33,7 +33,7 @@ Read the [environment setup guide](developer_guide/env_setup.md) first to setup 
 ## Build YuniKorn for Kubernetes
 
 Prerequisite:
-- Golang, check [yunikorn-k8shim/.go_version](https://github.com/apache/yunikorn-k8shim/blob/master/.go_version) to see the version of Yunikorn request.
+- Golang: check the `.go_version` file in the root of the repositories for the version Yunikorn requires. The minimum version can change per release branch.  Earlier Go versions might cause compilation issues. 
 
 You can build the scheduler for Kubernetes from [yunikorn-k8shim](https://github.com/apache/yunikorn-k8shim) project.
 The build procedure will build all components into a single executable that can be deployed and running on Kubernetes.


### PR DESCRIPTION
# What's this issue for?
After [YUNIKORN-1411](https://issues.apache.org/jira/browse/YUNIKORN-1411) updated the k8shim dependencies. 
go 1.16 is not work for Yunikorn master, and document need to be update.
I change the tutorial in "Build and Run" page, point the prerequisite to [.go_version](https://github.com/apache/yunikorn-k8shim/blob/master/.go_version)

# Issue type
* [x] Improvement

# Apache jira
[https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-1421](https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-1421)

# How to test?
`./local-build.sh`
## screenshot
![image](https://user-images.githubusercontent.com/48400525/203684289-f2714211-9cce-4549-afe1-b1ee94392b5e.png)


