### PR TITLE
[YUNIKORN-1380] Multiple pages URL were broken for website

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,6 +24,9 @@ module.exports = {
   favicon: 'img/yunikorn.ico',
   organizationName: 'apache',
   projectName: 'yunikorn-core',
+  customFields: {
+    trailingSlashes: true,
+  },
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'zh-cn'],


### PR DESCRIPTION
## Why are the changes needed?
Multiple pages URL were borken. For example share feedback to the YuniKorn Community link on the website is broken.

They point to:
https://yunikorn.apache.org/community/get_involved/reporting_issues

While they should be pointing to the:
https://yunikorn.apache.org/community/reporting_issues/

## What changes were proposed in this pull request?
Updated the trailingSlashes property to be true for docusaurus.

## How was this PR tested?
Tested with local-build 

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/20658072/204710816-964cc809-a5d3-469d-a2a0-da040ca1280f.png">



