### PR TITLE
[YUNIKORN-1346] Mistake in online sample code

### DIFF
--- a/docs/user_guide/resource_quota_mgmt.md
+++ b/docs/user_guide/resource_quota_mgmt.md
@@ -273,19 +273,21 @@ First we set the following configuration to YuniKorn's configmap:
 
 ```yaml
 partitions:
-  - name: default
-    placementrules:
-    - name: tag
-      value: namespace
-      create: true
-      parent:
-      - name: tag
-        value: namespace.parentqueue
-    queues:
-    - name: root
-      queues:
-      - name: production
-      - name: development
+   - name: default
+     placementrules:
+        - name: tag
+          value: namespace
+          create: true
+          parent:
+             name: tag
+             value: namespace.parentqueue
+     queues:
+        - name: root
+          queues:
+             - name: production
+               parent: true
+             - name: development
+               parent: true
 ```
 
 The configuration used for the namespace to queue mapping is the same as [above](#Namespace-to-queue-mapping).


### PR DESCRIPTION
# What's this issue for?
[YUNIKORN-1346] Mistake in online sample code
To fix error type of `Parent`, It should be a `PlacementRule` not slice and add `QueuesConfig` of Value `Parent`
# Issue type
 Improvement
# Apache jira
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-1346

# How to test?
./local-build.sh run

## screenshot
![image](https://user-images.githubusercontent.com/21263915/205442073-f1c6c752-9cfd-46bb-852c-2b6215909707.png)