### PR TITLE
[YUNIKORN-1444] jira signup procedure

### DIFF
--- a/i18n/zh-cn/docusaurus-plugin-content-pages/community/how_to_contribute.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-pages/community/how_to_contribute.md
@@ -29,6 +29,26 @@ YuniKorn 使用：
 * GitHub 用于 Pull Requests(以后简称拉取请求)来管理代码审查和更改本身。
 * Markdown 文档，版本化并存储在网站存储库中。
 
+## Jira 注册
+
+2022 年 11 月，由于虚假 Jira 帐户的涌入造成大量垃圾邮件，Apache Infra 终止了 ASF Jira 帐户的公共注册。
+这篇 [博客文章 - 英语](https://infra.apache.org/blog/jira-public-signup-disabled.html) 讨论了这个决定。
+如果您想为 YuniKorn 开一个 Jira 票证并且没有 ASF Jira 账户，YuniKorn PMC 可以为您创建一个账户。
+
+有两个选项可以轻松申请帐户：
+* 电邮 [private@yunikorn](mailto:private@yunikorn.apache.org?subject=jira%20account%20request)
+* Slack [YuniKorn Slack](https://join.slack.com/t/yunikornworkspace/shared_invite/enQtNzAzMjY0OTI4MjYzLTBmMDdkYTAwNDMwNTE3NWVjZWE1OTczMWE4NDI2Yzg3MmEyZjUyYTZlMDE5M2U4ZjZhNmYyNGFmYjY4ZGYyMGE)
+
+我们需要以下信息来创建一个帐户：
+* 电子邮件
+* 首选用户名 (不允许使用连字符)
+* 备用用户名 (如果首选的已经在使用中)
+* 显示名称 (如果它与用户名不同)
+
+:::caution
+不要在 Slack 的频道中分享上述信息，在频道中联系，其中一位 PMC 成员将在私人聊天中联系以收集详细信息。  
+:::
+
 ## 发现问题
 我们使用 JIRA 问题库来跟踪该项目的错误。
 找到您想要处理的问题，或者如果您发现了新问题，请提交新问题。

--- a/src/pages/community/how_to_contribute.md
+++ b/src/pages/community/how_to_contribute.md
@@ -29,6 +29,25 @@ YuniKorn uses:
 * GitHub Pull Requests to manage code review and the change itself.
 * Markdown for documentation, versioned and stored in the website repository.
 
+## Jira Signup
+In November 2022, due to an influx of false Jira accounts creating a flood of spam tickets, Apache Infra ended public signups to ASF Jira accounts.
+This [blog post](https://infra.apache.org/blog/jira-public-signup-disabled.html) discusses the decision.
+If you want to open a Jira ticket for YuniKorn and do not have an ASF Jira account, the YuniKorn PMC can create an account for you.
+
+There are two options to easily request an account:
+* email [private@yunikorn](mailto:private@yunikorn.apache.org?subject=jira%20account%20request)
+* Slack [YuniKorn slack](https://join.slack.com/t/yunikornworkspace/shared_invite/enQtNzAzMjY0OTI4MjYzLTBmMDdkYTAwNDMwNTE3NWVjZWE1OTczMWE4NDI2Yzg3MmEyZjUyYTZlMDE5M2U4ZjZhNmYyNGFmYjY4ZGYyMGE)
+
+We need the following information to create an account:
+* email address
+* preferred username (hyphens not allowed)
+* alternate username (in case the preferred one is already in use)
+* display name (if it is different from the username)
+
+:::caution
+Don't share the above information in a channel on slack, reach out on a channel and one of the PMC members will reach out in a private chat to collect the details.  
+:::
+
 ## Find an issue
 We use JIRA issues to track bugs for this project.
 Find an issue that you would like to work on, or file a new one if you have discovered a new issue.


### PR DESCRIPTION
Update the how to contribute page with the signup procedure for jira following the auto signup disablement by Apache Infra.

Special focus on the zn-ch translation.