### PR TITLE
[YUNIKORN-1380] Multiple pages URL were broken for website

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,6 +24,9 @@ module.exports = {
   favicon: 'img/yunikorn.ico',
   organizationName: 'apache',
   projectName: 'yunikorn-core',
+  customFields: {
+    trailingSlashes: true,
+  },
   i18n: {
     defaultLocale: 'en',
     locales: ['en', 'zh-cn'],

--- a/src/pages/community/get_involved.md
+++ b/src/pages/community/get_involved.md
@@ -34,7 +34,7 @@ importance of this diversity and the value of "The Apache Way".  We welcome any 
 Please join us through one of the following channels:
 
 ### Contribute through github
-- Basic steps of contributing to project is explained here - [How to contribute](how_to_contribute)
+- Basic steps of contributing to project is explained here - [How to contribute](/community/how_to_contribute)
 
 ### Communication Channels
 
@@ -81,7 +81,7 @@ import TabItem from '@theme/TabItem';
 We welcome you to try our latest releases and share your experiences.
 
 Any point, if you are facing any issues:
-- Raise an issue or a feedback in the JIRA as per our [guide](reporting_issues).
+- Raise an issue or a feedback in the JIRA as per our [guide](/community/reporting_issues).
 - Clarify / Seek help in the YuniKorn slack `#yunikorn-user` channel
 
 ### Other feedback mechanisms

--- a/src/pages/community/how_to_contribute.md
+++ b/src/pages/community/how_to_contribute.md
@@ -32,7 +32,7 @@ YuniKorn uses:
 ## Find an issue
 We use JIRA issues to track bugs for this project.
 Find an issue that you would like to work on, or file a new one if you have discovered a new issue.
-For help with reporting issues look at the [how to report an issue](reporting_issues).
+For help with reporting issues look at the [how to report an issue](/community/reporting_issues).
 
 The easiest way to get started working with the code base is to pick up a really easy
 JIRA and work on that. This will help you get familiar with the code base, build system,
@@ -66,7 +66,7 @@ It’s better for everyone if we maintain discipline about the scope of each pat
 In general, if you find a bug while working on a specific feature, file a JIRA for the bug, check if you can assign it to yourself and fix it independently of the feature.
 This helps us to differentiate between bug fixes and features and allows us to build stable maintenance releases.
 
-Make sure you have observed the recommendations in the [coding guidelines](coding_guidelines).
+Make sure you have observed the recommendations in the [coding guidelines](/community/coding_guidelines).
 Before you commit your changes and create a pull request based on your changes you should run the code checks. 
 These same checks are run as part of the pull request workflow.
 The pull request workflow performs the following checks:
@@ -114,7 +114,7 @@ We follow the version numbering as described in the [version numbering](https://
 The master branch *must* use a pseudo version.
 See the [Go module dependencies](/docs/next/developer_guide/dependencies) for updating the pseudo version.
 The release branches *must* use branch version.
-See the [release procedure](release_procedure#tag-and-update-release-for-version) on when and how to update the tags and references during the release creation. 
+See the [release procedure](/community/release_procedure#tag-and-update-release-for-version) on when and how to update the tags and references during the release creation. 
 
 ## Documentation updates
 Documentation is published and maintained as part of the website.

--- a/src/pages/community/reporting_issues.md
+++ b/src/pages/community/reporting_issues.md
@@ -34,7 +34,7 @@ Please do not disclose the issue to any public forum before working with the sec
 If you have an issue with YuniKorn operation, please follow these guidelines:
 
 If you are having an issue with setup, configuration, or some other form of behavior not matching your expectation, join the user mailing list and ask your questions in that forum.
-See the [Get Involved](get_involved#communication-channels) page for information on mailing lists.
+See the [Get Involved](community/get_involved#communication-channels) page for information on mailing lists.
 You can also ask the YuniKorn slack channel for help, details on how to join can be found on the same page.
 If you have a bug that needs a fix in the code or in the documentation, please follow the procedure in [Filing a JIRA](#filing-a-jira-for-yunikorn-issues) below.
 

--- a/src/pages/community/reporting_issues.md
+++ b/src/pages/community/reporting_issues.md
@@ -34,7 +34,7 @@ Please do not disclose the issue to any public forum before working with the sec
 If you have an issue with YuniKorn operation, please follow these guidelines:
 
 If you are having an issue with setup, configuration, or some other form of behavior not matching your expectation, join the user mailing list and ask your questions in that forum.
-See the [Get Involved](community/get_involved#communication-channels) page for information on mailing lists.
+See the [Get Involved](/community/get_involved#communication-channels) page for information on mailing lists.
 You can also ask the YuniKorn slack channel for help, details on how to join can be found on the same page.
 If you have a bug that needs a fix in the code or in the documentation, please follow the procedure in [Filing a JIRA](#filing-a-jira-for-yunikorn-issues) below.
 


### PR DESCRIPTION
### Why are the changes needed?

Verified the whole website and found some broken pages' URLs even after trailingSlashes enabled. 

### What changes were proposed in this pull request?
This PR proposed absolute file paths on the other hand are resolved relative to the content root, in our case /community/

### How was this PR tested?
Tested with local-build

<img width="1417" alt="image" src="https://user-images.githubusercontent.com/20658072/206336995-806e34dc-9798-4f97-b132-318e5fbf57d5.png">
