### PR TITLE
[YUNIKORN-1521] fix broken release announcement links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -156,16 +156,15 @@ module.exports = {
           label: 'Docs',
           to: 'docs',
           position: 'right',
-          activeBaseRegex: `docs/(?!next/(support|team|resources))`,
           items: [
             {
               label: 'Master',
               to: 'docs/next/',
-              activeBaseRegex: `docs/next/(?!support|team|resources)`,
             },
             {
               label: versions[0],
               to: 'docs/',
+              // required for correct style on current version menu item
               activeBaseRegex: `docs/(?!${versions.join('|')}|next)`,
             },
             ...versions.slice(1).map((version) => ({

--- a/i18n/zh-cn/docusaurus-plugin-content-pages/release-announce/0.12.2.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-pages/release-announce/0.12.2.md
@@ -26,7 +26,7 @@ under the License.
 Apache YuniKorn (Incubating) 是一个独立的资源调度器，旨在管理和调度容器编排框架（如 Kubernetes）上的大数据工作负载，用于本地和云端用例。
 
 ## 概述
-The Apache YuniKorn (Incubating) 社区在此版本中修复了 19 个 [JIRA问题](https://issues.apache.org/jira/browse/YUNIKORN-1038?filter=12351270) 。
+The Apache YuniKorn (Incubating) 社区在此版本中修复了 19 个 [JIRA问题](https://issues.apache.org/jira/issues/?filter=12351270) 。
 0.12.2 版本主要是一个维护版本，目的是为了更好地兼容当前的 Kubernetes 版本。这个版本里还修复了 0.12.1 中发现的影响动态卷使用的关键问题，因此我们敦促 0.12.1 的所有用户进行升级。
 
 发布负责人: Craig Condit

--- a/src/pages/release-announce/0.12.2.md
+++ b/src/pages/release-announce/0.12.2.md
@@ -25,7 +25,7 @@ under the License.
 We are pleased to announce that the Apache YuniKorn (Incubating) community has voted to release 0.12.2. Apache YuniKorn (Incubating) is a standalone resource scheduler, designed for managing, and scheduling Big Data workloads on container orchestration frameworks like Kubernetes for on-prem and on-cloud use cases.
 
 ## Overview
-The Apache YuniKorn (Incubating) community has fixed 19 [JIRAs](https://issues.apache.org/jira/browse/YUNIKORN-1038?filter=12351270) in this release. Version 0.12.2 is primarily a maintenance release to allow better compatibility with current Kubernetes releases. There is also a fix for a critical issue affecting the usage of dynamic volumes that was found in 0.12.1, so all users of 0.12.1 are urged to upgrade.
+The Apache YuniKorn (Incubating) community has fixed 19 [JIRAs](https://issues.apache.org/jira/issues/?filter=12351270) in this release. Version 0.12.2 is primarily a maintenance release to allow better compatibility with current Kubernetes releases. There is also a fix for a critical issue affecting the usage of dynamic volumes that was found in 0.12.1, so all users of 0.12.1 are urged to upgrade.
 
 Release manager: Craig Condit
 

--- a/src/pages/release-announce/1.1.0.md
+++ b/src/pages/release-announce/1.1.0.md
@@ -26,7 +26,7 @@ under the License.
 We are pleased to announce that the Apache YuniKorn community has voted to release 1.1.0. Apache YuniKorn is a standalone resource scheduler, designed for managing, and scheduling Big Data workloads on container orchestration frameworks like Kubernetes for on-prem and on-cloud use cases.
 
 ## Overview
-The Apache YuniKorn community has fixed 87 [JIRAs](https://issues.apache.org/jira/issues/?filter=12352202) in this release. 
+The Apache YuniKorn community has fixed 87 [JIRAs](https://issues.apache.org/jira/issues/?filter=12351692) in this release. 
 
 Release manager: Peter Bacsko
 

--- a/src/pages/release-announce/1.1.0.md
+++ b/src/pages/release-announce/1.1.0.md
@@ -26,7 +26,7 @@ under the License.
 We are pleased to announce that the Apache YuniKorn community has voted to release 1.1.0. Apache YuniKorn is a standalone resource scheduler, designed for managing, and scheduling Big Data workloads on container orchestration frameworks like Kubernetes for on-prem and on-cloud use cases.
 
 ## Overview
-The Apache YuniKorn community has fixed 87 [JIRAs](https://issues.apache.org/jira/issues/?filter=12351692) in this release. 
+The Apache YuniKorn community has fixed 89 [JIRAs](https://issues.apache.org/jira/issues/?filter=12351692) in this release. 
 
 Release manager: Peter Bacsko
 


### PR DESCRIPTION
### What is this PR for?
Point to web accessible links in announcements
Remove unneeded base regexp in config

Note: zh-cn release announcement for 1.1.0 is missing

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1521

### How should this be tested?
Links in the release announcements should open correct page

### Screenshots (if appropriate)
Followed link in the v1.1.0 release announcement for fixed jiras: 
![image](https://user-images.githubusercontent.com/7152971/209901670-5f5fc830-5d92-4c3a-837c-e1b1960abbdb.png)
