### PR TITLE
[YUNIKORN-1572] update roadmap for 1.3.0 to reflect the sync

### DIFF
--- a/src/pages/community/roadmap.md
+++ b/src/pages/community/roadmap.md
@@ -31,11 +31,11 @@ Release Details:
 - Development status: [Issue tracker](https://issues.apache.org/jira/issues/?filter=12348416)
 
 Planned major features:
-- [YUNIKORN-984](https://issues.apache.org/jira/browse/YUNIKORN-984) [Umbrella] User quota tracking
-- [YUNIKORN-1196](https://issues.apache.org/jira/browse/YUNIKORN-1196) Upgrade K8s build dependency
-- [YUNIKORN-1275](https://issues.apache.org/jira/browse/YUNIKORN-1275) Support arbitrary resources in namespace annotation
-- [YUNIKORN-1306](https://issues.apache.org/jira/browse/YUNIKORN-1306) [Umbrella] Enhanced user and group handling
-- [YUNIKORN-1](https://issues.apache.org/jira/browse/YUNIKORN-1) Support app/task priority aware scheduling
+- [YUNIKORN-1461](https://issues.apache.org/jira/browse/YUNIKORN-1461) [Umbrella] Preemption support
+- [YUNIKORN-1562](https://issues.apache.org/jira/browse/YUNIKORN-1562) plugin mode: remove status update completely
+- [YUNIKORN-1548](https://issues.apache.org/jira/browse/YUNIKORN-1548) [Umbrella] Revamp E2E test - Phase 2
+- [YUNIKORN-1544](https://issues.apache.org/jira/browse/YUNIKORN-1544) [Umbrella] User quota tracking - Phase 2
+- [YUNIKORN-1573](https://issues.apache.org/jira/browse/YUNIKORN-1573) [Umbrella] User & Group Based Quota Enforcement
 
 Supported Kubernetes versions and the Kubernetes dependency will be defined and finalised during the development cycle.
 


### PR DESCRIPTION
### What is this PR for?
During the community sync the roadmap for 1.3.0 was discussed. The roadmap on the website should be updated to reflect that discussion.

https://docs.google.com/document/d/165gzC7uhcKc5XDWiMYSRKBiPQBy2tDtXADUPuhGlUa0/edit#

```
YuniKorn 1.3:

Preemption
Plugin mode: leverage pre-enqueue plugin
E2e test updates
Application History / usage tracking
User & group Usage enforcement
```


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring