### PR TITLE
[YUNIKORN-1671] Remove unused API timeout configuration

### DIFF
--- a/docs/design/config_v2.md
+++ b/docs/design/config_v2.md
@@ -180,7 +180,6 @@ specified. Note that these values are subject to change in future releases.
       log.level: "0"
       kubernetes.qps: "1000"
       kubernetes.burst: "1000"
-      kubernetes.apiClientTimeout: "30s"
       admissionController.webHook.amServiceName: "yunikorn-admission-controller-service"
       admissionController.webHook.schedulerServiceAddress: "yunikorn-service:9080"
       admissionController.filtering.processNamespaces: ""

--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -447,7 +447,6 @@ data:
   log.level: "0"
   kubernetes.qps: "1000"
   kubernetes.burst: "1000"
-  kubernetes.apiClientTimeout: "30s"
   admissionController.webHook.amServiceName: "yunikorn-admission-controller-service"
   admissionController.webHook.schedulerServiceAddress: "yunikorn-service:9080"
   admissionController.filtering.processNamespaces: ""
@@ -670,17 +669,6 @@ Default: `1000`
 Example:
 ```yaml
 kubernetes.burst: "500"
-```
-#### kubernetes.apiClientTimeout
-Controls how long to wait until the various API clients time out.
-
-A change to this setting requires a restart of YuniKorn to take effect.
-
-Default: `30s`
-
-Example:
-```yaml
-kubernetes.apiClientTimeout: "60s"
 ```
 ### Admission controller webhook settings
 


### PR DESCRIPTION
Revert "[YUNIKORN-1609] Document kubernetes.apiClientTimeout setting (#271)"

This reverts commit 2ebfe09152d47282c47f3e136dc160e58e71c752.

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1671

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
