### PR TITLE
[YUNIKORN-1831] Incorrect key name used for user info in pod annotati…

### DIFF
--- a/docs/user_guide/usergroup_resolution.md
+++ b/docs/user_guide/usergroup_resolution.md
@@ -86,13 +86,15 @@ metadata:
   annotations:
     yunikorn.apache.org/user.info: "
     {
-      username: \"yunikorn\",
-      groups: [
+      \"user\": \"yunikorn\",
+      \"groups\": [
         \"developers\",
         \"devops\"
       ]
     }"
 ```
+
+(NOTE: for historical reason, "username" is used in label "yunikorn.apache.org/username", whereas, "user" is used in the annotation here)
 
 However, to enhance security, the following is enforced in the admission controller:
 * not every user in the cluster is allowed to attach this annotation, only those which are configured

--- a/docs/user_guide/usergroup_resolution.md
+++ b/docs/user_guide/usergroup_resolution.md
@@ -94,8 +94,6 @@ metadata:
     }"
 ```
 
-(NOTE: for historical reason, "username" is used in label "yunikorn.apache.org/username", whereas, "user" is used in the annotation here)
-
 However, to enhance security, the following is enforced in the admission controller:
 * not every user in the cluster is allowed to attach this annotation, only those which are configured
 * if the annotation is missing, the admission controller will add this information automatically


### PR DESCRIPTION
…on in user guide example

### What is this PR for?
This PR is to fix the documentation about setting user info in annotation.

There are two issues:
1. The "username" word should be "user" which is implemented in code
2. There need to be quote around the keys "user", "groups"

### What type of PR is it?
* [ ] - Bug Fix
* [x ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* https://issues.apache.org/jira/browse/YUNIKORN-1831

### How should this be tested?
Tested in locally built doc and content was tested in real cluster

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
