### PR TITLE
[YUNIKORN-1958] Fix link to merge script

### DIFF
--- a/src/pages/community/how_to_contribute.md
+++ b/src/pages/community/how_to_contribute.md
@@ -194,7 +194,7 @@ There are three options for committing a change:
 * manually using the git command line
 * use the GitHub web UI "squash and merge" button 
 
-A [simple shell script](https://github.com/apache/yunikorn-release/tree/master/tools/merge-pr.sh) to help with a squash and merge is part of the release repository.
+A [simple shell script](https://github.com/apache/yunikorn-release/tree/master/tools/merge_pr.sh) to help with a squash and merge is part of the release repository.
 The script handles the checkout, merge and commit message preparation.
 As part of the merge process conflicts can be resolved by the committer and added to the commit.
 The commit message is prepared but not finalised. The committer can edit, and cleanup, the message before the commit is made.


### PR DESCRIPTION
### What is this PR for?
The link to the merge script on the [how to contribute](https://yunikorn.apache.org/community/how_to_contribute#committing-a-change) page i is broken. It points to:
https://github.com/apache/yunikorn-release/blob/master/tools/merge-pr.sh
and should point to:
https://github.com/apache/yunikorn-release/blob/master/tools/merge_pr.sh

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1958

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
