### PR TITLE
[YUNIKORN-1966] Increase auto-publish timeout in github action

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -36,7 +36,7 @@ jobs:
           docker build -t yunikorn/yunikorn-website:2.0.0 . --build-arg NODE_VERSION=${NODE_VERSION}
           docker run --name yunikorn-site -d -p 3000:3000 yunikorn/yunikorn-website:2.0.0
           bash -c 'while true; do curl -Is http://localhost:3000 | head -n 1 | grep "OK"; [ $? -eq 0 ] && break; sleep 3; done'
-        timeout-minutes: 10
+        timeout-minutes: 20
       - name: "Checkout asf-site branch"
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
### What is this PR for?
Looks like 10 minutes is not enough sometimes. IMO, we should increase the timeout in auto-publish (failure `auto-publish` in https://github.com/apache/yunikorn-site/actions/runs/6123469907/job/16621418122)

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1966

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
