### PR TITLE
[YUNIKORN-1976] Fix incorrect downloads link

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -61,7 +61,7 @@ module.exports = {
     announcementBar: {
       id: 'new_release',
       content:
-          '1.3.0 has been released, check the <a href="community/download">DOWNLOADS</a>.',
+          '1.3.0 has been released, check the <a href="/community/download">DOWNLOADS</a>.',
       backgroundColor: '#fafbfc',
       textColor: '#091E42',
     },


### PR DESCRIPTION
### What is this PR for?
This is the way to reproduce incorrect downloads link
- click link https://yunikorn.apache.org/community/roadmap
- Then click DOWNLOADS as follows
 <img width="381" alt="截圖 2023-09-13 上午12 05 51" src="https://github.com/apache/yunikorn-site/assets/4344302/0b1296ef-f310-4994-b597-647d6095fcca">
 
- the `DOWNLOADS` direct to https://yunikorn.apache.org/community/roadmap/community/download . This link does not exist --> 404 not found

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1976

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
