### PR TITLE
[YUNIKORN-1982] Enable manual triggering for GitHub CI

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -19,7 +19,6 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch: {}
 
 jobs:
   build:

--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -19,6 +19,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch: {}
 
 jobs:
   build:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -19,6 +19,7 @@ on:
   pull_request:
     branches:
       - master
+  workflow_dispatch: {}
 
 jobs:
   license:


### PR DESCRIPTION
### What is this PR for?
Allow running manually from the github ui. 
Everyone can manually run the CI on their fork.

github docs 
1. https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow
2. https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

This will not affect **ANY** github action we are running.
### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
 [YUNIKORN-1982](https://issues.apache.org/jira/browse/YUNIKORN-1982)

