### PR TITLE
[YUNIKORN-1960] Add updating DOAP file to release tasks

### DIFF
--- a/src/pages/community/release_procedure.md
+++ b/src/pages/community/release_procedure.md
@@ -61,9 +61,10 @@ Simplified release procedure:
 2. Stabilize the release by fixing test failures and bugs only
 3. Tag update release for a new version to prepare a release candidate, e.g `v1.3.0-1` for RC1
 4. Update the CHANGELOG
-5. Configure [release-configs.json](https://github.com/apache/yunikorn-release/tree/master/tools/release-configs.json)
-6. Run script [build-release.py](https://github.com/apache/yunikorn-release/tree/master/tools/build-release.py) to generate source code tarball, checksum and signature.
-7. Voting and releasing the candidate
+5. Update the DOAP file
+6. Configure [release-configs.json](https://github.com/apache/yunikorn-release/tree/master/tools/release-configs.json)
+7. Run script [build-release.py](https://github.com/apache/yunikorn-release/tree/master/tools/build-release.py) to generate source code tarball, checksum and signature.
+8. Voting and releasing the candidate
 
 ## Step-by-step procedure
 Branching and tagging can, and in most cases will, require changes in the go mod files.
@@ -119,6 +120,20 @@ Follow these steps to generate the list:
 - Click the button `Configure Release Notes`
 - Select the style `Text` and click `create`
 - Scroll to the bottom of the page and copy the content of the text area and update the CHANGELOG file in the ../release-top-level-artifacts directory.
+
+### Update the DOAP file
+A [DOAP file](https://github.com/apache/yunikorn-site/blob/master/doap_YuniKorn.rdf) containing project details has to be maintained.
+Update the DOAP file with the release version and release date.
+
+```xml
+<release>
+  <Version>
+    <name>YuniKorn x.y.z</name>
+    <created>YYYY-MM-DD</created>
+    <revision>x.y.z</revision>
+  </Version>
+</release>
+```
 
 ### Run the release tool
 Please check the [signing your first release](#signing-your-first-release) before proceeding here for details on signing a release.

--- a/src/pages/community/release_procedure.md
+++ b/src/pages/community/release_procedure.md
@@ -61,10 +61,9 @@ Simplified release procedure:
 2. Stabilize the release by fixing test failures and bugs only
 3. Tag update release for a new version to prepare a release candidate, e.g `v1.3.0-1` for RC1
 4. Update the CHANGELOG
-5. Update the DOAP file
-6. Configure [release-configs.json](https://github.com/apache/yunikorn-release/tree/master/tools/release-configs.json)
-7. Run script [build-release.py](https://github.com/apache/yunikorn-release/tree/master/tools/build-release.py) to generate source code tarball, checksum and signature.
-8. Voting and releasing the candidate
+5. Configure [release-configs.json](https://github.com/apache/yunikorn-release/tree/master/tools/release-configs.json)
+6. Run script [build-release.py](https://github.com/apache/yunikorn-release/tree/master/tools/build-release.py) to generate source code tarball, checksum and signature.
+7. Voting and releasing the candidate
 
 ## Step-by-step procedure
 Branching and tagging can, and in most cases will, require changes in the go mod files.
@@ -120,20 +119,6 @@ Follow these steps to generate the list:
 - Click the button `Configure Release Notes`
 - Select the style `Text` and click `create`
 - Scroll to the bottom of the page and copy the content of the text area and update the CHANGELOG file in the ../release-top-level-artifacts directory.
-
-### Update the DOAP file
-A [DOAP file](https://github.com/apache/yunikorn-site/blob/master/doap_YuniKorn.rdf) containing project details has to be maintained.
-Update the DOAP file with the release version and release date.
-
-```xml
-<release>
-  <Version>
-    <name>YuniKorn x.y.z</name>
-    <created>YYYY-MM-DD</created>
-    <revision>x.y.z</revision>
-  </Version>
-</release>
-```
 
 ### Run the release tool
 Please check the [signing your first release](#signing-your-first-release) before proceeding here for details on signing a release.
@@ -477,6 +462,20 @@ Links for the releases have to follow these rules:
 
 A limited set of three (3) or four (4) releases should be maintained in the table for direct access.
 Older releases not mentioned in the table can still be accessed via the archive link on the bottom of the page and do not need to be referenced.
+
+### Update the DOAP file
+A [DOAP file](https://github.com/apache/yunikorn-site/blob/master/doap_YuniKorn.rdf) containing project details has to be maintained.
+Update the DOAP file with the release version and release date.
+
+```xml
+<release>
+  <Version>
+    <name>YuniKorn x.y.z</name>
+    <created>YYYY-MM-DD</created>
+    <revision>x.y.z</revision>
+  </Version>
+</release>
+```
 
 ## Signing your first release
 If you haven't signed any releases before, read the documentation to [generate signing key](https://infra.apache.org/openpgp.html#generate-key)


### PR DESCRIPTION
### What is this PR for?
A DOAP file is required for all Apache projects. For yunikorn, it is maintained in the yunikorn-site repo: https://github.com/apache/yunikorn-site/blob/master/doap_YuniKorn.rdf. This file should be updated as part of uploading the release notes to the website. This PR adds that step to the release procedure. 


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-1960

### How should this be tested?
Th modified .md file can be rendered by any supported tool to view the changes. 

### Screenshots (if appropriate)
<img width="861" alt="image" src="https://github.com/apache/yunikorn-site/assets/50546120/3dcd5501-6296-4b00-9355-b1d2fbad65d6">

