### PR TITLE
[YUNIKORN-2228] Fix doc admissionController.filtering.defaultQueue default should be root.default

### DIFF
--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -907,7 +907,7 @@ For certain use-cases, there may be a need to skip adding a default queue name t
 
 Adding default queue name should be avoided when `provided` rule is used in conjunction with other placement rules and `provided` rule is higher in the hierarchy. If default queue label is added whenever there is no queue name specified, all the apps will be placed via `provided` rule and the other rules after that will never be executed.
 
-Default: empty
+Default: `root.default`
 
 Example:
 ```yaml


### PR DESCRIPTION
### What is this PR for?
in  https://yunikorn.apache.org/docs/next/user_guide/service_config/#admissioncontrollerfilteringdefaultqueue

admissionController.filtering.defaultQueue default value should be `root.default` instead of empty. (see https://github.com/apache/yunikorn-k8shim/blob/28995cd7289256be3d3b8f820d438ddec36778b3/pkg/admission/conf/am_conf.go#L76)

### What type of PR is it?
* [x] - Bug Fix

### Todos
N/A

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2228

### How should this be tested?
N/A

### Screenshots (if appropriate)
N/A

### Questions:
N/A
