### PR TITLE
[YUNIKORN-2274] Improve document version routing in YuniKorn documentation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,7 +76,7 @@ module.exports = {
       items: [
         {
           to: 'docs/',
-          label: 'Quick Start',
+          label: 'Docs',
         },
         {
           to: 'community/roadmap',
@@ -154,24 +154,8 @@ module.exports = {
         },
         {
           label: 'Docs',
-          to: 'docs',
+          type: 'docsVersionDropdown',
           position: 'right',
-          items: [
-            {
-              label: 'Master',
-              to: 'docs/next/',
-            },
-            {
-              label: versions[0],
-              to: 'docs/',
-              // required for correct style on current version menu item
-              activeBaseRegex: `docs/(?!${versions.join('|')}|next)`,
-            },
-            ...versions.slice(1).map((version) => ({
-              label: version,
-              to: `docs/${version}/`,
-            })),
-          ],
         },
         {
           type: 'localeDropdown',


### PR DESCRIPTION
### What is this PR for?
- Utilize the navbar item 'docsVersionDropdown' to support versioned routes.
- Rename the navbar item 'Quick Start' tab to 'Docs.'
  (The reason is that after changing to 'docsVersionDropdown,' the original versioned item name is no longer named 'Docs'.)
  (After referencing the layout of this page 'https://docusaurus.io/docs', I think changing 'Quick Start' to 'Docs' is better.')


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos


### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2274

### How should this be tested?
Run:

> yarn run start 
yarn run start --locale=zh-cn

### Screenshots (if appropriate)
![YUNIKORN-2274](https://github.com/apache/yunikorn-site/assets/26764036/c03e7c34-01a4-4781-ad71-3c58e92428cd)


### Questions:
NA
