### PR TITLE
[YUNIKORN-2316] Update REST API docs for /ws/v1/scheduler/node-utilizations

### DIFF
--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -1382,6 +1382,8 @@ Node details include host and rack name, capacity, resources, utilization, and a
 
 Show how every node is distributed with regard to dominant resource utilization.
 
+**Status** : Deprecated since v1.5.0 and will be removed in the next major release. Replaced with `/ws/v1/scheduler/node-utilizations`.
+
 **URL** : `/ws/v1/scheduler/node-utilization`
 
 **Method** : `GET`
@@ -1394,7 +1396,7 @@ Show how every node is distributed with regard to dominant resource utilization.
 
 **Content examples**
 
-```text
+```json
 {
     "type": "vcore",
     "utilization": [
@@ -1416,6 +1418,82 @@ Show how every node is distributed with regard to dominant resource utilization.
       ...  
     ]
 }
+```
+
+### Error response
+
+**Code** : `500 Internal Server Error`
+
+**Content examples**
+
+```json
+{
+    "status_code": 500,
+    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
+    "description": "system error message. for example, json: invalid UTF-8 in string: .."
+}
+```
+
+## Node utilizations
+
+Show the nodes utilization of different types of resources in a cluster.
+
+**URL** : `/ws/v1/scheduler/node-utilizations`
+
+**Method** : `GET`
+
+**Auth required** : NO
+
+### Success response
+
+**Code** : `200 OK`
+
+**Content examples**
+
+```json
+[
+    {
+        "clusterId": "mycluster",
+        "partition": "default",
+        "utilizations": [
+            {
+                "type": "pods",
+                "utilization": [
+                    {
+                        "bucketName": "0-10%",
+                        "numOfNodes": 2,
+                        "nodeNames": [
+                            "primary-node",
+                            "second-node"
+                        ]
+                    },
+                    {
+                        "bucketName": "10-20%"
+                    },
+                    ...
+                ]
+            },
+            {
+                "type": "vcores",
+                "utilization": [
+                    {
+                        "bucketName": "0-10%",
+                        "numOfNodes": 2,
+                        "nodeNames": [
+                            "primary-node",
+                            "second-node"
+                        ]
+                    },
+                    {
+                        "bucketName": "10-20%"
+                    },
+                    ...
+                ]
+            },
+            ...
+        ]
+    }
+]
 ```
 
 ### Error response

--- a/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/scheduler.md
+++ b/i18n/zh-cn/docusaurus-plugin-content-docs/current/api/scheduler.md
@@ -954,6 +954,139 @@ Yunikorn调度器能透过REST API来返回多个对象的信息
 }
 ```
 
+## 节点主要资源使用率
+
+每个节点在主要资源利用率的分布。
+
+**状态 (Status)** : 自v1.5.0起已被弃用，并将在下一个主要版本中移除。替代为 `/ws/v1/scheduler/node-utilizations`。
+
+**位置（URL）** : `/ws/v1/scheduler/node-utilization`
+
+**方法（Method）** : `GET`
+
+**需求权限** : NO
+
+### 成功时的响应
+
+**返回代码** : `200 OK`
+
+**示例**
+
+```json
+{
+    "type": "vcore",
+    "utilization": [
+      {
+        "bucketName": "0-10%",
+        "numOfNodes": 1,
+        "nodeNames": [
+          "aethergpu"
+        ]
+      },
+      {
+        "bucketName": "10-20%",
+        "numOfNodes": 2,
+        "nodeNames": [
+            "primary-node",
+            "second-node"
+        ]
+      },
+      ...  
+    ]
+}
+```
+
+### 错误时的响应
+
+**返回代码** : `500 Internal Server Error`
+
+**示例**
+
+```json
+{
+    "status_code": 500,
+    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
+    "description": "system error message. for example, json: invalid UTF-8 in string: .."
+}
+```
+
+## 节点资源使用率
+
+每个节点各种资源的利用率分布。
+
+**位置（URL）** : `/ws/v1/scheduler/node-utilizations`
+
+**方法（Method）** : `GET`
+
+**需求权限** : NO
+
+### 成功时的响应
+
+**返回代码** :`200 OK`
+
+**示例**
+
+```json
+[
+    {
+        "clusterId": "mycluster",
+        "partition": "default",
+        "utilizations": [
+            {
+                "type": "pods",
+                "utilization": [
+                    {
+                        "bucketName": "0-10%",
+                        "numOfNodes": 2,
+                        "nodeNames": [
+                            "primary-node",
+                            "second-node"
+                        ]
+                    },
+                    {
+                        "bucketName": "10-20%"
+                    },
+                    ...
+                ]
+            },
+            {
+                "type": "vcores",
+                "utilization": [
+                    {
+                        "bucketName": "0-10%",
+                        "numOfNodes": 2,
+                        "nodeNames": [
+                            "primary-node",
+                            "second-node"
+                        ]
+                    },
+                    {
+                        "bucketName": "10-20%"
+                    },
+                    ...
+                ]
+            },
+            ...
+        ]
+    }
+]
+```
+
+### 错误时的响应
+
+**返回代码** : `500 Internal Server Error`
+
+**示例**
+
+
+```json
+{
+    "status_code": 500,
+    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
+    "description": "system error message. for example, json: invalid UTF-8 in string: .."
+}
+```
+
 ## Goroutines信息
 
 获取当前运行的goroutines的堆栈跟踪（stack traces）


### PR DESCRIPTION
### What is this PR for?
1. Add /ws/v1/scheduler/node-utilizations endpoint doc.
2. Fix the 'text' to 'json' conversion in the previously unaddressed part of the [YUNIKORN-2194 PR](https://github.com/apache/yunikorn-site/pull/372#pullrequestreview-1812501203).
3. Add the missing part of the Chiniese doc for /ws/v1/scheduler/node-utilization
4. Mark /ws/v1/scheduler/node-utilization deprecated.


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2316

### How should this be tested?
> yarn start --locale=zh-cn
> yarn start

<img width="1181" alt="image" src="https://github.com/apache/yunikorn-site/assets/26764036/7be87d1b-8453-4342-9c83-3416d99b47dc">

<img width="1201" alt="image" src="https://github.com/apache/yunikorn-site/assets/26764036/dc513d42-3c36-4565-8347-f54ba921a94e">

### Questions:
NA
