### PR TITLE
[YUNIKORN-2340] Upgrade actions versions in Github Action workflow

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Check out latest code on master branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: './yunikorn-master'
       - name: "Build and run website locally"
@@ -38,7 +38,7 @@ jobs:
           bash -c 'while true; do curl -Is http://localhost:3000 | head -n 1 | grep "OK"; [ $? -eq 0 ] && break; sleep 3; done'
         timeout-minutes: 20
       - name: "Checkout asf-site branch"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           path: './yunikorn-asf-site'
           ref: 'asf-site'

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
       - name: Check license


### PR DESCRIPTION
### What is this PR for?
Bump below actions verions to surpress the "Node.js 16 actions are deprecated." warning message:

1. actions/checkout (v3 -> v4)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
Update below repo's actions version:
1. yunikorn-k8shim
2. yunikorn-core
3. yunikorn-scheduler-interface
4. yunikorn-web

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2340

### How should this be tested?
Tested in Github action.  Create a pull request to master branch and check the Actions result.
ex: https://github.com/chenyulin0719/yunikorn-site/actions/runs/7695347162

### Screenshots (if appropriate)

After:
<img width="1455" alt="image" src="https://github.com/apache/yunikorn-site/assets/26764036/eff8871c-1f9a-4960-896a-cfd770421411">

Before:
<img width="1451" alt="image" src="https://github.com/apache/yunikorn-site/assets/26764036/149c3b7e-9eb4-4ff0-a2e5-f26e87889634">



### Questions:
NA
