### PR TITLE
[YUNIKORN-2426] Remove periodic state dump doc

### DIFF
--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -2025,27 +2025,6 @@ The current content shows the cached objects:
 
 **Code**: `500 Internal Server Error`
 
-## Enable or disable periodic state dump
-
-Endpoint to enable a state dump to be written periodically.
-
-**Status** : Deprecated and ignored since v1.2.0, no replacement.
-
-**URL** : `/ws/v1/periodicstatedump/{switch}/{periodSeconds}`
-
-**Method** : `PUT`
-
-**Auth required** : NO
-
-### Success response
-
-None
-
-### Error response
-
-**Code**: `400 Bad Request`
-
-
 ## Batch Events
 
 Endpoint is used to retrieve a batch of event records.

--- a/docs/user_guide/queue_config.md
+++ b/docs/user_guide/queue_config.md
@@ -62,7 +62,6 @@ The queues configuration is explained below.
 
 Optionally the following keys can be defined for a partition:
 * [placementrules](#placement-rules)
-* [statedumpfilepath](#statedump-filepath) (deprecated since v1.2.0)
 * [limits](#limits)
 * nodesortpolicy
 * preemption
@@ -203,14 +202,6 @@ The placement rules are defined and documented in the [placement rule](placement
 
 Each partition can have only one set of placement rules defined. 
 If no rules are defined the placement manager is not started and each application *must* have a queue set on submit.
-
-### Statedump filepath
-
-**Status** : Deprecated and ignored since v1.2.0, no replacement.
-
-```yaml
-statedumpfilepath: <path/to/statedump/file>
-```
 
 ### Limits
 Limits define a set of limit objects for a queue, and can be set on a queue at any level.


### PR DESCRIPTION
### What is this PR for?
`periodicstatedump` endpoint has been deprecated since version 1.2.0 #242  , and we have now removed the remaining doc.


### What type of PR is it?
* [x] - Improvement

### What is the Jira issue?
[YUNIKORN-2426](https://issues.apache.org/jira/browse/YUNIKORN-2426)



