### PR TITLE
[YUNIKORN-2464] Missing markdown list indentation @docs/design/historical_usage_tracking.md

### DIFF
--- a/docs/design/historical_usage_tracking.md
+++ b/docs/design/historical_usage_tracking.md
@@ -46,7 +46,7 @@ Work to be tracked under [YUNIKORN-1628](https://issues.apache.org/jira/browse/Y
 ## Goals
 
 -   Implementation of an event stream for an application, including:  
-  -   State changes
+   -   State changes
   -   Asks and allocation changes
 -   Implementation of an event stream for a node, including:
   -   State changes

--- a/docs/design/historical_usage_tracking.md
+++ b/docs/design/historical_usage_tracking.md
@@ -46,14 +46,14 @@ Work to be tracked under [YUNIKORN-1628](https://issues.apache.org/jira/browse/Y
 ## Goals
 
 -   Implementation of an event stream for an application, including:  
-     -   State changes
-  -   Asks and allocation changes
+    -   State changes
+    -   Asks and allocation changes
 -   Implementation of an event stream for a node, including:
-  -   State changes
-  -   Allocation changes
+    -   State changes
+    -   Allocation changes
 -   Implementation of an event stream for a queue, including:
-  -   State changes
-  -   Usage changes
+    -   State changes
+    -   Usage changes
 -   Define a REST interface for event retrieval
 
 ## Non Goals

--- a/docs/design/historical_usage_tracking.md
+++ b/docs/design/historical_usage_tracking.md
@@ -45,7 +45,7 @@ Work to be tracked under [YUNIKORN-1628](https://issues.apache.org/jira/browse/Y
 
 ## Goals
 
--   Implementation of an event stream for an application, including:
+-   Implementation of an event stream for an application, including:  
   -   State changes
   -   Asks and allocation changes
 -   Implementation of an event stream for a node, including:

--- a/docs/design/historical_usage_tracking.md
+++ b/docs/design/historical_usage_tracking.md
@@ -61,7 +61,7 @@ Work to be tracked under [YUNIKORN-1628](https://issues.apache.org/jira/browse/Y
 -   Add a data store for the historical data
 -   Display the event information
 -   Rebuild data on recovery
-  -   Historical data will not be rebuild
+    -   Historical data will not be rebuild
 -   Authentication and Authorisation on the REST interface
 
 ## Existing Event System

--- a/docs/design/historical_usage_tracking.md
+++ b/docs/design/historical_usage_tracking.md
@@ -46,7 +46,7 @@ Work to be tracked under [YUNIKORN-1628](https://issues.apache.org/jira/browse/Y
 ## Goals
 
 -   Implementation of an event stream for an application, including:  
-   -   State changes
+     -   State changes
   -   Asks and allocation changes
 -   Implementation of an event stream for a node, including:
   -   State changes


### PR DESCRIPTION
### What is this PR for?
This PR addresses a formatting issue in the `historical_usage_tracking.md` documentation on the Apache YuniKorn website. Specifically, it introduces the necessary markdown list indentation under the "Goals" and "non-Goals" section to ensure that the documentation is structured and readable.

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
NA

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-2464

### How should this be tested?

```
yarn run start
```

### Screenshots (if appropriate)
Before:
![image](https://github.com/apache/yunikorn-site/assets/91534261/f79cedac-681d-4d3c-9ee7-9b0f282cc8c5)
![image](https://github.com/apache/yunikorn-site/assets/91534261/3ae232c3-8bc9-4a62-b8a3-cfc1cdfa541c)
After:
![image](https://github.com/apache/yunikorn-site/assets/91534261/7bcb8b1f-7998-4dc9-8818-ea5e81ae9758)
![image](https://github.com/apache/yunikorn-site/assets/91534261/a24b31b7-07ff-4387-ada1-6bd9ce53b6da)
### Questions:
NA
