### PR TITLE
[YUNIKORN-2522] Move e2e test doc from k8shim to website

### DIFF
--- a/docs/developer_guide/e2e_test.md
+++ b/docs/developer_guide/e2e_test.md
@@ -1,0 +1,97 @@
+---
+id: e2e_test
+title: End-to-End Testing
+---
+
+<!--
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+-->
+
+End-to-end (e2e) tests for YuniKorn-K8shim provide a mechanism to test end-to-end behavior of the system, and is the last signal to ensure end user operations match developer specifications. 
+
+The primary objectives of the e2e tests are to ensure a consistent and reliable behavior of the yunikorn code base, and to catch hard-to-test bugs before users do, when unit and integration tests are insufficient.
+
+The e2e tests are built atop of [Ginkgo](https://onsi.github.io/ginkgo/) and [Gomega](https://github.com/onsi/gomega). There are a host of features that this Behavior-Driven Development (BDD) testing framework provides, and it is recommended that the developer read the documentation prior to diving into the tests.
+
+Below is the structure of e2e tests, all contained within the [yunikorn-k8shim](https://github.com/apache/yunikorn-k8shim).
+* `test/e2e/` contains tests for YuniKorn Features like Scheduling, Predicates etc
+* `test/e2e/framework/configManager` manages & maintains the test and cluster configuration
+* `test/e2e/framework/helpers` contains utility modules for k8s client, (de)serializers, rest api client and other common libraries.
+* `test/e2e/testdata` contains all the test related data like configmaps, pod specs etc
+
+## Pre-requisites
+This project requires Go to be installed. On OS X with Homebrew you can just run `brew install go`.
+OR follow this doc for deploying go https://golang.org/doc/install
+
+## Understanding the Command Line Arguments
+* `yk-namespace` - namespace under which YuniKorn is deployed. [Required]
+* `kube-config` - path to kube config file, needed for k8s client [Required]
+* `yk-host` - hostname of the YuniKorn REST Server, defaults to localhost.   
+* `yk-port` - port number of the YuniKorn REST Server, defaults to 9080.
+* `yk-scheme` - scheme of the YuniKorn REST Server, defaults to http.
+* `timeout` -  timeout for all tests, defaults to 24 hours
+
+## Launching Tests
+
+### Trigger through CLI
+* Begin by installing a new cluster dedicated to testing, such as one named 'yktest'
+```shell
+./scripts/run-e2e-tests.sh -a install -n yktest -v kindest/node:v1.28.0
+```
+
+* Launching CI tests is as simple as below.
+```shell
+# We need to add a 'kind' prefix to the argument of the run-e2e-tests.sh -n command.
+kubectl config use-context kind-yktest 
+ginkgo -r -v ci -timeout=2h -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
+```
+
+* Launching all the tests can be done as.
+```shell
+ginkgo -r -v -timeout=2h -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
+```
+
+* Launching all the tests in specified e2e folder.
+e.g. test/e2e/user_group_limit/
+```shell 
+cd test/e2e/
+ginkgo -r user_group_limit -v -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
+```
+
+* Launching specified test file.
+```shell
+cd test/e2e/
+ginkgo run -r -v --focus-file "admission_controller_test.go" -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
+```
+
+* Launching specified test.
+e.g. Run test with ginkgo.it() spec name "Verify_maxapplications_with_a_specific_group_limit"
+```shell 
+cd test/e2e/
+ginkgo run -r -v --focus "Verify_maxapplications_with_a_specific_group_limit" -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
+```
+
+* Launching all the tests except specified test file.
+```shell
+cd test/e2e/
+ginkgo run -r -v --skip-file "admission_controller_test.go" -- -yk-namespace "yunikorn" -kube-config "$HOME/.kube/config"
+```
+
+* Delete the cluster after we finish testing (this step is optional).
+```shell
+./scripts/run-e2e-tests.sh -a cleanup -n yktest
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -76,6 +76,7 @@ module.exports = {
             'developer_guide/deployment',
             'developer_guide/openshift_development',
             'developer_guide/scheduler_object_states',
+            'developer_guide/e2e_test',
             {
                 type: 'category',
                 label: 'Designs',


### PR DESCRIPTION
### What is this PR for?
This PR moves the e2e doc from k8shim to website for easier access.
Most part remain the same expect the follow modifications:
1. Add examples of instruction arguments like `--focus-file` and `--skip-file`, as mentioned in [YUNIKORN-2215](https://issues.apache.org/jira/browse/YUNIKORN-2215)
2. Modify explanation and add a link of k8shim project (At line 30)
3. remove the `$` mark in code block
4. remove `\` in code block because there is a fold button in the UI which can wrap long strings

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
N/A

### What is the Jira issue?
[YUNIKORN-2522](https://issues.apache.org/jira/browse/YUNIKORN-2522/)

### How should this be tested?
local build

### Screenshots (if appropriate)
<img width="1503" alt="截圖 2024-04-09 下午1 58 06" src="https://github.com/apache/yunikorn-site/assets/107598572/9fa2acf7-0408-4c0f-91ac-a02bd3251a5f">

### Questions:
N/A