### PR TITLE
[YUNIKORN-2462] incorrect gang annotations in example

### DIFF
--- a/docs/user_guide/gang_scheduling.md
+++ b/docs/user_guide/gang_scheduling.md
@@ -180,32 +180,37 @@ Each Spark job runs 2 types of pods, driver and executor. Hence, we need to defi
 The annotations for the driver pod looks like:
 
 ```yaml
-Annotations:
-  yunikorn.apache.org/schedulingPolicyParameters: “placeholderTimeoutSeconds=30”
-  yunikorn.apache.org/taskGroupName: “spark-driver”
-  yunikorn.apache.org/taskGroup: “
-    TaskGroups: [
-     {
-       Name: “spark-driver”,
-       minMember: 1,
-       minResource: {
-         Cpu: 1,
-         Memory: 2Gi
-       },
-       Node-selector: ...,
-       Tolerations: ...,
-       Affinity: ...
-     },
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    spark-app-id: spark-driver
+    queue: root.sandbox
+  annotations:
+    yunikorn.apache.org/schedulingPolicyParameters: "placeholderTimeoutInSeconds=30 gangSchedulingStyle=Hard"
+    yunikorn.apache.org/task-group-name: "spark-driver"
+    yunikorn.apache.org/task-groups: |-
+      [{
+          "name": "spark-driver",
+          "minMember": 1,
+          "minResource": {
+            "cpu": "1",
+            "memory": "2Gi"
+          },
+          "nodeSelector": {},
+          "tolerations": [],
+          "affinity": {}
+      },
       {
-        Name: “spark-executor”,
-        minMember: 10, 
-        minResource: {
-          Cpu: 1,
-          Memory: 2Gi
-        }
-      }
-  ]
-  ”
+          "name": "spark-executor",
+          "minMember": 1,
+          "minResource": {
+            "cpu": "1",
+            "memory": "2Gi"
+          }
+      }]
+spec:
+  schedulerName: yunikorn
 ```
 
 :::note
@@ -216,10 +221,18 @@ See the [Spark documentation](https://spark.apache.org/docs/latest/configuration
 For all the executor pods,
 
 ```yaml
-Annotations:
-  # the taskGroup name should match to the names
-  # defined in the taskGroups field
-  yunikorn.apache.org/taskGroupName: “spark-executor”
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    spark-app-id: spark-executor
+    queue: root.sandbox
+  annotations:
+    # the taskGroup name should match to the names
+    # defined in the taskGroups field
+    yunikorn.apache.org/task-group-name: "spark-executor"
+spec:
+  schedulerName: yunikorn
 ```
 
 Once the job is submitted to the scheduler, the job won’t be scheduled immediately.

--- a/docs/user_guide/gang_scheduling.md
+++ b/docs/user_guide/gang_scheduling.md
@@ -180,37 +180,29 @@ Each Spark job runs 2 types of pods, driver and executor. Hence, we need to defi
 The annotations for the driver pod looks like:
 
 ```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    spark-app-id: spark-driver
-    queue: root.sandbox
-  annotations:
-    yunikorn.apache.org/schedulingPolicyParameters: "placeholderTimeoutInSeconds=30 gangSchedulingStyle=Hard"
-    yunikorn.apache.org/task-group-name: "spark-driver"
-    yunikorn.apache.org/task-groups: |-
-      [{
-          "name": "spark-driver",
-          "minMember": 1,
-          "minResource": {
-            "cpu": "1",
-            "memory": "2Gi"
-          },
-          "nodeSelector": {},
-          "tolerations": [],
-          "affinity": {}
-      },
-      {
-          "name": "spark-executor",
-          "minMember": 1,
-          "minResource": {
-            "cpu": "1",
-            "memory": "2Gi"
-          }
-      }]
-spec:
-  schedulerName: yunikorn
+annotations:
+  yunikorn.apache.org/schedulingPolicyParameters: "placeholderTimeoutInSeconds=30 gangSchedulingStyle=Hard"
+  yunikorn.apache.org/task-group-name: "spark-driver"
+  yunikorn.apache.org/task-groups: |-
+    [{
+        "name": "spark-driver",
+        "minMember": 1,
+        "minResource": {
+          "cpu": "1",
+          "memory": "2Gi"
+        },
+        "nodeSelector": {},
+        "tolerations": [],
+        "affinity": {}
+     },
+     {
+        "name": "spark-executor",
+        "minMember": 1,
+        "minResource": {
+          "cpu": "1",
+          "memory": "2Gi"
+        }
+     }]
 ```
 
 :::note
@@ -221,18 +213,10 @@ See the [Spark documentation](https://spark.apache.org/docs/latest/configuration
 For all the executor pods,
 
 ```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    spark-app-id: spark-executor
-    queue: root.sandbox
-  annotations:
-    # the taskGroup name should match to the names
-    # defined in the taskGroups field
-    yunikorn.apache.org/task-group-name: "spark-executor"
-spec:
-  schedulerName: yunikorn
+annotations:
+  # the taskGroup name should match to the names
+  # defined in the taskGroups field
+  yunikorn.apache.org/task-group-name: "spark-executor"
 ```
 
 Once the job is submitted to the scheduler, the job won’t be scheduled immediately.


### PR DESCRIPTION
### What is this PR for?
Modified example:Gang scheduling for Spark jobs

### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2462

### How should this be tested?
Run web tests locally, Additionally, we can try to perform Gang scheduling for Spark jobs.
[[YUNIKORN-1755] update deployments/examples/spark/](https://github.com/apache/yunikorn-k8shim/pull/601)

### Screenshots (if appropriate)
![2024-04-10 02-01-24 的螢幕擷圖](https://github.com/apache/yunikorn-site/assets/71066027/3d3f353c-63e4-4910-bc97-a559d44685cf)
![2024-04-10 02-01-42 的螢幕擷圖](https://github.com/apache/yunikorn-site/assets/71066027/4c8fb3ed-1867-4a91-9b73-bdb36ac33873)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
