### PR TITLE
[YUNIKORN-2591] Document placement rules always

### DIFF
--- a/docs/user_guide/queue_config.md
+++ b/docs/user_guide/queue_config.md
@@ -201,7 +201,8 @@ partitions:
 The placement rules are defined and documented in the [placement rule](placement_rules.md) document.
 
 Each partition can have only one set of placement rules defined. 
-If no rules are defined the placement manager is not started and each application *must* have a queue set on submit.
+If no rules are defined, `implicit provided rule` will be applied.
+Each application *must* have a queue set on submit.
 
 ### Limits
 Limits define a set of limit objects for a queue, and can be set on a queue at any level.

--- a/docs/user_guide/queue_config.md
+++ b/docs/user_guide/queue_config.md
@@ -201,7 +201,7 @@ partitions:
 The placement rules are defined and documented in the [placement rule](placement_rules.md) document.
 
 Each partition can have only one set of placement rules defined. 
-If no rules are defined, `implicit provided rule` will be applied.
+If no rules are defined, [provided rule](placement_rules#provided-rule) will be applied.
 Each application *must* have a queue set on submit.
 
 ### Limits

--- a/versioned_docs/version-1.4.0/user_guide/queue_config.md
+++ b/versioned_docs/version-1.4.0/user_guide/queue_config.md
@@ -202,7 +202,8 @@ partitions:
 The placement rules are defined and documented in the [placement rule](placement_rules.md) document.
 
 Each partition can have only one set of placement rules defined. 
-If no rules are defined the placement manager is not started and each application *must* have a queue set on submit.
+If no rules are defined, [provided rule](placement_rules#provided-rule) will be applied.
+Each application *must* have a queue set on submit.
 
 ### Statedump filepath
 

--- a/versioned_docs/version-1.5.0/user_guide/queue_config.md
+++ b/versioned_docs/version-1.5.0/user_guide/queue_config.md
@@ -201,7 +201,8 @@ partitions:
 The placement rules are defined and documented in the [placement rule](placement_rules.md) document.
 
 Each partition can have only one set of placement rules defined. 
-If no rules are defined the placement manager is not started and each application *must* have a queue set on submit.
+If no rules are defined, [provided rule](placement_rules#provided-rule) will be applied.
+Each application *must* have a queue set on submit.
 
 ### Limits
 Limits define a set of limit objects for a queue, and can be set on a queue at any level.


### PR DESCRIPTION
### What is this PR for?  
The current [doc says](https://yunikorn.apache.org/docs/user_guide/queue_config#placement-rules):

If no rules are defined the placement manager is not started and each application must have a queue set on submit.

This is not correct, we moved to placement rules always in [YUNIKORN-1793](https://issues.apache.org/jira/browse/YUNIKORN-1793) in YuniKorn 1.4 The documentation needs to be updated to reflect that.

According to [this code](https://github.com/apache/yunikorn-core/blob/master/pkg/scheduler/placement/placement.go#L182-L188), it will create implicit provided rule if we don't specify the rule.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [x] - also correct version 1.4 and 1.5

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2591

### How should this be tested?
Github CI

### Screenshots (if appropriate)

### Questions:
N/A
