### PR TITLE
[YUNIKORN-2561] Add topology spread constraint reference to gang scheduling doc

### DIFF
--- a/docs/user_guide/gang_scheduling.md
+++ b/docs/user_guide/gang_scheduling.md
@@ -85,9 +85,8 @@ one for the driver pod and the other one for the executor pods.
 
 #### How to define task groups?
 
-The task group definition is a copy of the app’s real pod definition, values for fields like resources, node-selector, toleration
-and affinity should be the same as the real pods. This is to ensure the scheduler can reserve resources with the
-exact correct pod specification.
+The task group definition is a copy of the app’s real pod definition, values for fields like resources, node-selector, toleration, affinity and topology spread constraints
+should be the same as the real pods. This is to ensure the scheduler can reserve resources with the exact correct pod specification.
 
 #### Scheduling Policy Parameters
 
@@ -151,7 +150,8 @@ spec:
               },
               "nodeSelector": {},
               "tolerations": [],
-              "affinity": {}
+              "affinity": {},
+              "topologySpreadConstraints": []
           }]
     spec:
       schedulerName: yunikorn
@@ -180,28 +180,29 @@ Each Spark job runs 2 types of pods, driver and executor. Hence, we need to defi
 The annotations for the driver pod looks like:
 
 ```yaml
-Annotations:
+annotations:
   yunikorn.apache.org/schedulingPolicyParameters: “placeholderTimeoutSeconds=30”
   yunikorn.apache.org/taskGroupName: “spark-driver”
   yunikorn.apache.org/taskGroup: “
-    TaskGroups: [
+    taskGroups: [
      {
-       Name: “spark-driver”,
+       name: “spark-driver”,
        minMember: 1,
        minResource: {
-         Cpu: 1,
-         Memory: 2Gi
+         cpu: 1,
+         memory: 2Gi
        },
-       Node-selector: ...,
-       Tolerations: ...,
-       Affinity: ...
+       nodeSelector: ...,
+       tolerations: ...,
+       affinity: ...,
+       topologySpreadConstraints: ...
      },
       {
-        Name: “spark-executor”,
-        minMember: 10, 
+        name: “spark-executor”,
+        minMember: 10,
         minResource: {
-          Cpu: 1,
-          Memory: 2Gi
+          cpu: 1,
+          memory: 2Gi
         }
       }
   ]
@@ -223,7 +224,7 @@ Annotations:
 ```
 
 Once the job is submitted to the scheduler, the job won’t be scheduled immediately.
-Instead, the scheduler will ensure it gets its minimal resources before actually starting the driver/executors. 
+Instead, the scheduler will ensure it gets its minimal resources before actually starting the driver/executors.
 
 ## Gang scheduling Styles
 
@@ -265,7 +266,8 @@ spec:
               },
               "nodeSelector": {},
               "tolerations": [],
-              "affinity": {}
+              "affinity": {},
+              "topologySpreadConstraints": []
           }]
     spec:
       schedulerName: yunikorn
@@ -289,7 +291,7 @@ To verify if the configuration has been done completely and correctly, check the
 If you define 2 task groups, 1 with minMember 1 and the other with minMember 5, that means we are expecting 6 placeholder
 gets created once the job is submitted.
 2. Verify the placeholder spec is correct. Each placeholder needs to have the same info as the real pod in the same taskGroup.
-Check field including: namespace, pod resources, node-selector, toleration and affinity.
+Check field including: namespace, pod resources, node selector, toleration, affinity and topology spread constraints.
 3. Verify the placeholders can be allocated on correct type of nodes, and verify the real pods are started by replacing the placeholder pods.
 
 ## Troubleshooting


### PR DESCRIPTION
### What is this PR for?

Add references to topology spread constraints on task groups on the main gang scheduling doc page.

Implementation PR: https://github.com/apache/yunikorn-k8shim/pull/845

### What type of PR is it?
* [ ] - Bug Fix
* [X] - Improvement
* [X] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?

https://issues.apache.org/jira/browse/YUNIKORN-2561

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
