### PR TITLE
[YUNIKORN-2622] Some /debug/pprof/ API response tested is different from example response in docs

### DIFF
--- a/docs/api/system.md
+++ b/docs/api/system.md
@@ -23,6 +23,7 @@ under the License.
 -->
 
 These endpoints are for the [pprof](https://github.com/google/pprof) profiling tool.
+Also, they are `unstable` because they are entirely dependent on what version of the go compiler and stdlibs were used to build YuniKorn.
 
 ## pprof
 
@@ -173,7 +174,7 @@ trace: A trace of execution of the current program. You can specify the duration
 **Content examples**
 
 ```proto
-// binary data from proto
+/yunikorn-scheduler
 ```
 
 ## Profile
@@ -205,7 +206,7 @@ trace: A trace of execution of the current program. You can specify the duration
 **Content examples**
 
 ```proto
-// binary data from proto
+num_symbols: 1
 ```
 
 ## Trace		


### PR DESCRIPTION
### What is this PR for?
/debug/pprof/symbol
tested response on 1.5.1: num_symbols: 1
while doc: binary
https://yunikorn.apache.org/docs/next/api/system/#success-response-9

/debug/pprof/cmdline also:
tested response on 1.5.1: /yunikorn-scheduler
while doc: binary
https://yunikorn.apache.org/docs/next/api/system/#cmdline

and add unstable notice for /debug apis as discussed in the jira.


### What type of PR is it?
* [x] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2622

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
