### PR TITLE
[YUNIKORN-2269] remove the USER_LABEL_KEY from docs

### DIFF
--- a/docs/user_guide/usergroup_resolution.md
+++ b/docs/user_guide/usergroup_resolution.md
@@ -55,14 +55,6 @@ Assumption:
   Yunikorn assumes that all pods belonging to an application are owned by the same user. We recommend that the user label is added to every pod of an app. This is to ensure that there is no discrepency. 
 :::
 
-The `yunikorn.apache.org/username` key can be customized by overriding the default value using the `USER_LABEL_KEY`env variable in the [K8s Deployment](https://github.com/apache/yunikorn-release/blob/master/helm-charts/yunikorn/templates/deployment.yaml). This is particularly useful in scenarios where the user label is already being added or if the label has to be modified for some secuirty reasons. 
-
-```yaml          
-            env:
-            - name: USER_LABEL_KEY
-              value: "custom_user_label"
-```
-
 ### Group resolution
 
 Group membership resolution is pluggables and is defined here. Groups do not have to be part of provided user and group object. When the object is added to the cache the groups are automatically resolved based on the resolution that is configured.


### PR DESCRIPTION
### What is this PR for?
Since YUNIKORN-1405 was merged, core no longer supports USER_LABEL_KEY. Therefore, we should eliminate it from the documentation.
### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2269](https://issues.apache.org/jira/browse/YUNIKORN-2269)
### How should this be tested?

### Screenshots (if appropriate)
![image](https://github.com/apache/yunikorn-site/assets/72776271/79953f79-09e6-423e-ab1b-05a9c94b24d6)

