### PR TITLE
[YUNIKORN-2655] Cleanup REST API documentation

### DIFF
--- a/docs/api/cluster.md
+++ b/docs/api/cluster.md
@@ -67,13 +67,3 @@ As an example, here is a response from a cluster with 1 resource manager.
 ### Error response
 
 **Code** : `500 Internal Server Error`
-
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```

--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -571,7 +571,7 @@ In the example below there are three allocations belonging to two applications, 
 
 **Code** : `400 Bad Request` (URL query is invalid)
 
-**Code** : `404 Not Found` (Partition or Application not found)
+**Code** : `404 Not Found` (Partition or Queue not found)
 
 **Code** : `500 Internal Server Error`
 
@@ -1621,9 +1621,6 @@ yunikorn_scheduler_vcore_nodes_usage{range="(80%,90%]"} 0
 yunikorn_scheduler_vcore_nodes_usage{range="(90%,100%]"} 0
 yunikorn_scheduler_vcore_nodes_usage{range="[0,10%]"} 0
 ```
-### Error response
-
-**Code** : `500 Internal Server Error`
 
 ## Configuration validation
 

--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -131,15 +131,7 @@ Returns general information and statistics about a partition.
 
 **Code** : `500 Internal Server Error`
 
-**Content examples**
 
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## PlacementRules
 
@@ -299,17 +291,11 @@ For the default queue hierarchy (only `root.default` leaf queue exists) a simila
 
 ### Error response
 
-**Code** : `500 Internal Server Error`
+**Code** : `400 Bad Request` (URL query is invalid, missing partition name)
 
-**Content examples**
+**Code** : `404 Not Found` (Partition not found)
 
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
+**Code** : `500 Internal Server Error` 
 
 ## Applications
 
@@ -334,6 +320,14 @@ For active state, can narrow the result by status query parameters(case-insensit
 
 The content of the application object is the same as Queue Applications. See
  [Queue Applications](#queue-applications) for details.
+
+### Error Response
+
+**Code** : `400 Bad Request` (URL query is invalid)
+
+**Code** : `404 Not Found` (Partition not found)
+
+**Code** : `500 Internal Server Error` 
 
 ### Queue applications
 
@@ -575,17 +569,12 @@ In the example below there are three allocations belonging to two applications, 
 
 ### Error response
 
+**Code** : `400 Bad Request` (URL query is invalid)
+
+**Code** : `404 Not Found` (Partition or Application not found)
+
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## Application
 
@@ -733,17 +722,12 @@ Field `uuid` has been deprecated, would be removed from below response in YUNIKO
 
 ### Error response
 
+**Code** : `400 Bad Request` (URL query is invalid)
+
+**Code** : `404 Not Found` (Partition or Application not found)
+
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## UsersTracker
 ### Get users usage tracking information
@@ -840,17 +824,9 @@ Fetch all users usage given a Partition and displays general information about t
 ```
 
 ### Error response
+
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## UserTracker
 ### Get specific user usage tracking information
@@ -909,17 +885,11 @@ Fetch specific user usage given a Partition and displays general information abo
 
 ### Error response
 
-**Code** : `500 Internal Server Error`
+**Code** : `400 Bad Request` (URL query is invalid)
 
-**Content examples**
+**Code** : `404 Not Found` (User not found)
 
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
+**Code** : `500 Internal Server Error`  
 
 ## GroupsTracker
 ### Get groups usage tracking information
@@ -1014,15 +984,6 @@ Fetch all groups usage given a Partition and displays general information about 
 
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## GroupTracker
 ### Get specific group usage tracking information
@@ -1080,17 +1041,11 @@ Fetch specific group usage given a Partition and displays general information ab
 
 ### Error response
 
+**Code** : `400 Bad Request` (URL query is invalid)
+
+**Code** : `404 Not Found` (Group not found)
+
 **Code** : `500 Internal Server Error`
-
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## Nodes
 
@@ -1296,17 +1251,11 @@ Here you can see an example response from a 2-node cluster having 3 allocations.
 
 ### Error response
 
+**Code** : `400 Bad Request` (URL query is invalid)
+
+**Code** : `404 Not Found` (Partition not found)
+
 **Code** : `500 Internal Server Error`
-
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## Node
 
@@ -1418,17 +1367,11 @@ Node details include host and rack name, capacity, resources, utilization, and a
 
 ### Error response
 
+**Code** : `400 Bad Request` (URL query is invalid)
+
+**Code** : `404 Not Found` (Partition or Node not found)
+
 **Code** : `500 Internal Server Error`
-
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## Node utilization
 
@@ -1476,15 +1419,6 @@ Show how every node is distributed with regard to dominant resource utilization.
 
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## Node utilizations
 
@@ -1552,15 +1486,6 @@ Show the nodes utilization of different types of resources in a cluster.
 
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## Goroutines info
 
@@ -1643,15 +1568,6 @@ created by os/signal.init.0
 
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 ## Metrics
 
@@ -1705,6 +1621,9 @@ yunikorn_scheduler_vcore_nodes_usage{range="(80%,90%]"} 0
 yunikorn_scheduler_vcore_nodes_usage{range="(90%,100%]"} 0
 yunikorn_scheduler_vcore_nodes_usage{range="[0,10%]"} 0
 ```
+### Error response
+
+**Code** : `500 Internal Server Error`
 
 ## Configuration validation
 
@@ -1892,16 +1811,6 @@ Endpoint to retrieve historical data about the number of total applications by t
 
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
-
 ## Container history
 
 Endpoint to retrieve historical data about the number of total containers by timestamp.
@@ -1947,15 +1856,6 @@ Endpoint to retrieve historical data about the number of total containers by tim
 
 **Code** : `500 Internal Server Error`
 
-**Content examples**
-
-```json
-{
-    "status_code": 500,
-    "message": "system error message. for example, json: invalid UTF-8 in string: ..",
-    "description": "system error message. for example, json: invalid UTF-8 in string: .."
-}
-```
 
 
 ## Endpoint healthcheck
@@ -2180,5 +2080,7 @@ The number of active connections is limited. The default setting is 100 connecti
 ### Error responses
 
 **Code** : `400 Bad Request` (URL query is invalid)
+
 **Code** : `503 Service Unavailable` (Too many active streaming connections)
+
 **Code** : `500 Internal Server Error`


### PR DESCRIPTION
### What is this PR for?
The REST API documentation is not up to date with the current behaviour as it does not show any 400 or 404 errors returned by a number of API calls.

The error response only shows a 500 code with the same message for each call.

We should move to a simple list for each call showing the applicable errors like this:
```
### Error responses

**Code** : `400 Bad Request` (URL query is invalid, missing partition name)

**Code** : `404 Not Found` (Partition not found)

**Code** : `500 Internal Server Error` 
```
Remove the error examples as they do not add any detail required


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2655

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
