### PR TITLE
[YUNIKORN-2727] Fix Dead Links and Update readme for Docusaurus v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ pnpm run start
 ```
 
 ## Updating the site
-The website is built based using [docusaurus-v2](https://v2.docusaurus.io/docs/docs-introduction). 
+The website is built based using [docusaurus-v3](https://docusaurus.io/docs/3.2.1). 
 The pages and documentation are written in MD file format, the data required is located at:
 * `docusaurus.config.js` the main site layout and menu definition
 * `src/pages` the non-versioned static pages of the site

--- a/docs/developer_guide/deployment.md
+++ b/docs/developer_guide/deployment.md
@@ -119,7 +119,7 @@ kubectl create -f deployments/scheduler/admission-controller-secrets.yaml
 
 ## Deploy the Admission Controller
 
-Now we can deploy the admission controller as a service. This will automatically validate/modify incoming requests and objects, respectively, in accordance with the [example in Deploy the Scheduler](#Deploy-the-Scheduler). See the contents of the admission controller deployment and service in [admission-controller.yaml](https://github.com/apache/yunikorn-k8shim/blob/master/deployments/scheduler/admission-controller.yaml).
+Now we can deploy the admission controller as a service. This will automatically validate/modify incoming requests and objects, respectively, in accordance with the [example in Deploy the Scheduler](#deploy-the-scheduler). See the contents of the admission controller deployment and service in [admission-controller.yaml](https://github.com/apache/yunikorn-k8shim/blob/master/deployments/scheduler/admission-controller.yaml).
 
 ```
 kubectl create -f deployments/scheduler/admission-controller.yaml


### PR DESCRIPTION
Fix Dead Links and Update readme for Docusaurus v3

### What is this PR for?
#### Issue 1: Dead Link in "Deploy the Scheduler"
- Problem: Dead link at example in "Deploy the Scheduler" section.
- Current: https://yunikorn.apache.org/docs/developer_guide/deployment/#deploy-the-admission-controller
- Solution: Replace with correct links:
https://yunikorn.apache.org/docs/next/developer_guide/deployment/#deploy-the-scheduler
https://yunikorn.apache.org/docs/next/developer_guide/deployment/#Deploy-the-Scheduler
- Cause: Migration to Docusaurus v3 with strict URL regulations.

#### Issue 2: Outdated Docusaurus Version in README
- Problem: README mentions Docusaurus v2.
- Current: "The website is built based using docusaurus-v2."
- Solution: Update to v3.
- New: "The website is built based using Docusaurus v3."


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2727

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
