### PR TITLE
[YUNIKORN-2728] Config event.RESTResponseSize should be placed under …

### DIFF
--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -715,6 +715,16 @@ Example:
 event.requestCapacity: "500"
 ```
 
+#### event.RESTResponseSize
+Sets the maximum number of events that are returned by the batch event API (`/ws/v1/events/batch`).
+
+Default: `10000`
+
+Example:
+```yaml
+event.RESTResponseSize: "20000"
+```
+
 ### Health settings
 
 #### health.checkInterval
@@ -730,16 +740,6 @@ Default: `30s`
 Example:
 ```yaml
 health.checkInterval: "1m"
-```
-
-#### event.RESTResponseSize
-Sets the maximum number of events that are returned by the batch event API (`/ws/v1/events/batch`).
-
-Default: `10000`
-
-Example:
-```yaml
-event.RESTResponseSize: "20000"
 ```
 
 ### Log settings


### PR DESCRIPTION
### What is this PR for?
https://yunikorn.apache.org/docs/next/user_guide/service_config/#eventrestresponsesize
event.RESTResponseSize is an event-related config and should be placed under
[#event-system-settings](https://yunikorn.apache.org/docs/next/user_guide/service_config/#event-system-settings) instead of [#health-settings](https://yunikorn.apache.org/docs/next/user_guide/service_config/#health-settings)

### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
[YUNIKORN-2728](https://issues.apache.org/jira/browse/YUNIKORN-2728)
