### PR TITLE
[YUNIKORN-2524] add documentation for recovery queue (root.@recovery@)

### DIFF
--- a/docs/user_guide/queue_config.md
+++ b/docs/user_guide/queue_config.md
@@ -196,6 +196,15 @@ partitions:
                 {memory: 5G, vcore: 50}
 ```
 
+### Recovery queue
+
+The recovery queue, identified by the name `root.@recovery@`, is a dynamic queue that is not directly queryable. It is used exclusively during the initialization phase for already running allocations that are part of applications failing placement. Its primary function is to handle tasks that need to be reassigned or recovered without user intervention.
+
+- The queue is created dynamically and will disappear when it is no longer in use.
+- The queue does not have quotas or Access Control Lists (ACLs).
+- It cannot be submitted to directly by users. It is managed internally by YuniKorn for specific recovery operations.
+- While the queue is unqueryable directly, its existence and activities can be observed through the application RESTful API at [/ws/v1/partition/:partition/applications/:state](../api/scheduler#partition-applications).
+
 ### Placement rules
 
 The placement rules are defined and documented in the [placement rule](placement_rules.md) document.


### PR DESCRIPTION
### What is this PR for?
the recovery queue is unqueryable directly but we can observe the recovery queue name via app Restful API (`ws/v1/partition/%s/application/%s`).

Hence, we should write documents for recovery queue. Otherwise, it would be surprise to users when they see the incomprehensible queue and they get nothing from our docs.


This should be a full documentation of the recovery queue and its purpose. I think we overlooked that until now. With the change to set the force flag in the k8shim we now can see the queue.

We should explain the initialisation process and the roll of the queue:

- name @recovery@ and why that name
- the queue is a dynamic queue and will disappear when not used
- no quota, no ACL
- cannot be submitted to directly
- only used during initialisation for already running allocations that are part of applications that fail placement


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2524

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
