### PR TITLE
[YUNIKORN-2812] Add troubleshooting docs for bind pod volumes timeout

### DIFF
--- a/docs/user_guide/troubleshooting.md
+++ b/docs/user_guide/troubleshooting.md
@@ -217,6 +217,13 @@ the garbage collection is not working properly.
 
 *Solution*: check the placeholder `ownerReference` and the garbage collector in Kubernetes.    
 
+# Task failed with pod volume binding time out
+*Reason*: The timeout value for service.volumeBindTimeout (which is set at 10 seconds by default). 
+But some cases, the pod volume binding will take more time, for example:
+When a node brought in by the autoscaler where the csi-node daemonset hasn’t been installed yet, which causes a delay with the volume binding (15-20 seconds). 
+
+
+*Solution*: Increase the timeout value for service.volumeBindTimeout, for example, set it to 60 seconds.
 
 ## Still got questions?
 


### PR DESCRIPTION
### What is this PR for?
This Jira will add to the troubleshooting the recommendation to increase the timeout when bind pod volume timeout.

We then start work on [YUNIKORN-2804](https://issues.apache.org/jira/browse/YUNIKORN-2804) as soon as we have forked YuniKorn 1.6.


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
* Open an issue on Jira https://issues.apache.org/jira/browse/YUNIKORN-2812
* Put link here, and add [YUNIKORN-*Jira number*] in PR title, eg. `[YUNIKORN-2] Gang scheduling interface parameters`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
