### PR TITLE
[YUNIKORN-2814] [Docs] Add Yunikorn on spark(AWS) link to Run spark jobs page

### DIFF
--- a/docs/user_guide/workloads/run_spark.md
+++ b/docs/user_guide/workloads/run_spark.md
@@ -164,3 +164,10 @@ to YuniKorn and being considered as a job. The job is scheduled and running as t
 YuniKorn allocates the driver pod to a node, binds the pod and starts all the containers. Once the driver pod gets started,
 it requests for a bunch of executor pods to run its tasks. Those pods will be created in the same namespace as well and
 scheduled by YuniKorn as well.
+
+## Using YuniKorn as a custom scheduler for Apache Spark on Amazon EMR on EKS
+
+YuniKorn can be configured as a custom scheduler for Apache Spark jobs on Amazon EMR on EKS. This setup allows our resource management and scheduling algorithms on Kubernetes clusters.
+
+For a detailed guide on how to set up YuniKorn with Apache Spark on Amazon EMR on EKS, please refer to the [AWS EMR documentation](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/tutorial-yunikorn.html).
+


### PR DESCRIPTION
### What is this PR for?
We can add a section (Using YuniKorn as a custom scheduler for Apache Spark on Amazon EMR on EKS) reference this link: https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/tutorial-yunikorn.html


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2814

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
