### PR TITLE
[YUNIKORN-2905] Update deployment documentation for make image

### DIFF
--- a/docs/developer_guide/deployment.md
+++ b/docs/developer_guide/deployment.md
@@ -30,9 +30,7 @@ scheduler and admission controller. It is primarily intended for developers.
 
 ## Build docker image
 
-Under project root of the `yunikorn-k8shim`, run the command to build an image using the map for the configuration:
-
-Build docker image can be triggered by running following command.
+Under project root of the `yunikorn-k8shim`, run the command to build run the command to build YuniKorn Docker images:
 
 ```
 make image
@@ -42,14 +40,14 @@ make image
 ```
 make image DOCKER_ARCH=amd64 REGISTRY=apache VERSION=latest
 ```
-This command will build an `amd64` binary executable with version `latest` and the docker image tag is `yunikorn/yunikorn:scheduler-amd64-latest`. 
+Given the example, the tag would be `apache/yunikorn:scheduler-amd64-latest`.
 
-**Note** that the latest yunikorn images in docker hub are not updated anymore due to ASF policy. Hence, you should build both scheduler image and web image locally before deploying them.
+**Note** that the latest Yunikorn images in docker hub are not updated anymore due to ASF policy. Hence, you should build both scheduler image and web image locally before deploying them.
 
 **Note** that the image tag includes your build architecture. For Intel, it would be `amd64` and for Mac M1, it would be `arm64`.
 
 ## Setup RBAC for Scheduler
-In the example, RBAC are configured for the yuniKorn namespace.
+In the example, RBAC are configured for the Yunikorn namespace.
 The first step is to create the RBAC role for the scheduler, see [yunikorn-rbac.yaml](https://github.com/apache/yunikorn-k8shim/blob/master/deployments/scheduler/yunikorn-rbac.yaml)
 ```
 kubectl create -f deployments/scheduler/yunikorn-rbac.yaml

--- a/docs/developer_guide/deployment.md
+++ b/docs/developer_guide/deployment.md
@@ -31,17 +31,22 @@ scheduler and admission controller. It is primarily intended for developers.
 ## Build docker image
 
 Under project root of the `yunikorn-k8shim`, run the command to build an image using the map for the configuration:
+
+Build docker image can be triggered by running following command.
+
 ```
 make image
 ```
 
-This command will build an image. The image will be tagged with a default version, image tag and your build architecture. 
+**Note** that the default build uses a hardcoded registry and tag. If you want to build docker image with specific arch, version or registry, you can refer the following command.
+```
+make image DOCKER_ARCH=amd64 REGISTRY=apache VERSION=latest
+```
+This command will build an `amd64` binary executable with version `latest` and the docker image tag is `yunikorn/yunikorn:scheduler-amd64-latest`. 
 
-**Note** the default build uses a hardcoded user and tag. You *must* update the `IMAGE_TAG` variable in the `Makefile` to push to an appropriate repository. 
+**Note** that the latest yunikorn images in docker hub are not updated anymore due to ASF policy. Hence, you should build both scheduler image and web image locally before deploying them.
 
-**Note** the latest yunikorn images in docker hub are not updated anymore due to ASF policy. Hence, you should build both scheduler image and web image locally before deploying them.
-
-**Note** the imaging tagging includes your build architecture. For Intel, it would be `amd64` and for Mac M1, it would be `arm64`.
+**Note** that the image tag includes your build architecture. For Intel, it would be `amd64` and for Mac M1, it would be `arm64`.
 
 ## Setup RBAC for Scheduler
 In the example, RBAC are configured for the yuniKorn namespace.

--- a/docs/developer_guide/deployment.md
+++ b/docs/developer_guide/deployment.md
@@ -30,13 +30,13 @@ scheduler and admission controller. It is primarily intended for developers.
 
 ## Build docker image
 
-Under project root of the `yunikorn-k8shim`, run the command to build run the command to build YuniKorn Docker images:
+Under project root of the `yunikorn-k8shim`, run the command to build YuniKorn Docker images:
 
 ```
 make image
 ```
 
-**Note** that the default build uses a hardcoded registry and tag. If you want to build docker image with specific arch, version or registry, you can refer the following command.
+**Note** that the default build uses a hardcoded registry and tag. If you want to build docker image with a specific arch, version or registry, you can refer to the following command.
 ```
 make image DOCKER_ARCH=amd64 REGISTRY=apache VERSION=latest
 ```


### PR DESCRIPTION
### What is this PR for?
When I tried to do the same thing in the deployment section, I found that the description for the make image command was outdated.

For example, the IMAGE_TAG variable is no longer exist in the makefile.

Therefore, I've referred to yunikorn-k8shim's readme.md and its makefile, and rewritten the documentation to make it clearer.



### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2905
### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
