### PR TITLE
[YUNIKORN-2914] Update deployment documentation for extra description…

### DIFF
--- a/docs/developer_guide/deployment.md
+++ b/docs/developer_guide/deployment.md
@@ -144,5 +144,8 @@ Once this is done, web UI will be available at: http://localhost:9889.
 
 YuniKorn uses config maps for configurations, and it supports loading configuration changes automatically by watching config map changes using shared informers.
 
-To make configuration changes, simply update the content in the configmap, which can be done either via Kubernetes dashboard UI or command line. Note, changes made to the configmap might have some delay to be picked up by the scheduler.
+To make configuration changes, simply update the content in the configmap, which can be done either via Kubernetes dashboard UI or command line. 
 
+**Note** that the changes made to the configmap might have some delay to be picked up by the scheduler.
+
+**Note** that if you're using the configmap as a [subPath](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically) volume, the configuration hot refresh will not be triggered.


### PR DESCRIPTION
### What is this PR for?

I just saw there's a user asking about configmap hot reload question in the slack channel, can refer to[https://yunikornworkspace.slack.com/archives/CLNUW68MU/p1728327140557209]

I also checked the hot refresh part for Yunikorn's docs, and I think not everyone knows that if you mounted the configmap under the subpath, the hot reload will not be triggered.

Therefore, I want to add extra description about this part. 

### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2914`

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
