### PR TITLE
[YUNIKORN-2932] Update local dashboard url in Dev Environment Setup

### DIFF
--- a/docs/developer_guide/env_setup.md
+++ b/docs/developer_guide/env_setup.md
@@ -70,7 +70,7 @@ Dashboard Web UI. The dashboard may be deployed using the following steps:
     ```shell script
     kubectl proxy &
     ```
-3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login).
+3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login).
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-0.10.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-0.10.0/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-0.11.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-0.11.0/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-0.12.1/developer_guide/env_setup.md
+++ b/versioned_docs/version-0.12.1/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-0.12.2/developer_guide/env_setup.md
+++ b/versioned_docs/version-0.12.2/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-0.8.0/setup/env_setup.md
+++ b/versioned_docs/version-0.8.0/setup/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-0.9.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-0.9.0/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.0.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.0.0/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.1.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.1.0/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+1. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.2.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.2.0/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-3. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+3. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.3.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.3.0/developer_guide/env_setup.md
@@ -52,7 +52,7 @@ After setting up the local Kubernetes you need to deploy the dashboard using the
     ```shell script
     kubectl proxy &
     ```
-3. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login)
+3. access the dashboard at the following URL: [clickable link](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login)
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.4.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.4.0/developer_guide/env_setup.md
@@ -70,7 +70,7 @@ Dashboard Web UI. The dashboard may be deployed using the following steps:
     ```shell script
     kubectl proxy &
     ```
-3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login).
+3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login).
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.5.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.5.0/developer_guide/env_setup.md
@@ -70,7 +70,7 @@ Dashboard Web UI. The dashboard may be deployed using the following steps:
     ```shell script
     kubectl proxy &
     ```
-3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login).
+3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login).
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.5.1/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.5.1/developer_guide/env_setup.md
@@ -70,7 +70,7 @@ Dashboard Web UI. The dashboard may be deployed using the following steps:
     ```shell script
     kubectl proxy &
     ```
-3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login).
+3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login).
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.5.2/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.5.2/developer_guide/env_setup.md
@@ -70,7 +70,7 @@ Dashboard Web UI. The dashboard may be deployed using the following steps:
     ```shell script
     kubectl proxy &
     ```
-3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login).
+3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login).
 
 ### Access local Kubernetes cluster
 

--- a/versioned_docs/version-1.6.0/developer_guide/env_setup.md
+++ b/versioned_docs/version-1.6.0/developer_guide/env_setup.md
@@ -70,7 +70,7 @@ Dashboard Web UI. The dashboard may be deployed using the following steps:
     ```shell script
     kubectl proxy &
     ```
-3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login).
+3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login).
 
 ### Access local Kubernetes cluster
 


### PR DESCRIPTION
### What is this PR for?

According to the Kubernetes official documentation, the local dashboard URL in the 'Deploy and access dashboard' section needs to be updated to http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard-kong-proxy:443/proxy/#/login


### What type of PR is it?
* [ ] - Bug Fix
* [x] - Improvement
* [ ] - Feature
* [ ] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2932
