### PR TITLE
[YUNIKORN-2902]modify Dev Environment Setup k8s namespace

### DIFF
--- a/docs/developer_guide/env_setup.md
+++ b/docs/developer_guide/env_setup.md
@@ -70,7 +70,7 @@ Dashboard Web UI. The dashboard may be deployed using the following steps:
     ```shell script
     kubectl proxy &
     ```
-3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/#!/login).
+3. Access the dashboard [here](http://localhost:8001/api/v1/namespaces/kubernetes-dashboard/services/https:kubernetes-dashboard:/proxy/#!/login).
 
 ### Access local Kubernetes cluster
 


### PR DESCRIPTION
### What is this PR for?
modify kubernetes dashboard v2.0.0 url. According to https://stackoverflow.com/questions/57719573/services-kubernetes-dashboard-not-found-when-access-kubernetes-ui, kubernetes dashboard v2.0.0 provide different url.


### What type of PR is it?
* [ ] - Improvement

### What is the Jira issue?
* [YUNIKORN-2902](https://issues.apache.org/jira/browse/YUNIKORN-2902)modify Dev Environment Setup k8s namespace


