### PR TITLE
[YUNIKORN-2968] handle no content changes in auto-publish

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -53,5 +53,9 @@ jobs:
           git config --local user.email "yunikornscheduler@gmail.com"
           git config --local user.name "yunikorn-bot"
           git add .
-          git commit -aF ../asf-site-commit.txt
-          git push
+          if output=$(git status --porcelain) && [ -z "$output" ]; then
+            echo "nothing changed, skipping commit"
+          else
+            git commit -aF ../asf-site-commit.txt
+            git push
+          fi


### PR DESCRIPTION
### What is this PR for?
Any push to master will still trigger a build. That workflow will fail if it has nothing to commit into the asf-site branch. If there is no change in the content of the website we should just exit and let the build pass.

### What type of PR is it?
* [X] - Improvement

### What is the Jira issue?
[YUNIKORN-2968](https://issues.apache.org/jira/browse/YUNIKORN-2968)

### How should this be tested?
Local build with non content change