### PR TITLE
[YUNIKORN-2919] Document spark-operator: Account spark.memory.offHeap.size

### DIFF
--- a/docs/user_guide/workloads/run_spark.md
+++ b/docs/user_guide/workloads/run_spark.md
@@ -48,7 +48,7 @@ helm install yunikorn yunikorn/yunikorn --create-namespace --namespace yunikorn
 We should install `spark-operator` with `controller.batchScheduler.enable=true` and set `controller.batchScheduler.default=yunikorn` to enable Gang Scheduling. It's optional to set the default scheduler to YuniKorn since you can specify it later on, but it's recommended to do so.  
 Also, note that the total requested memory for the Spark job is the sum of memory requested for the driver and that for all executors, where each is computed as below:
 * Driver requested memory = `spark.driver.memory` + `spark.driver.memoryOverhead`
-* Executor requested memory = `spark.executor.memory` + `spark.executor.memoryOverhead` + `spark.executor.pyspark.memory`
+* Executor requested memory = `spark.executor.memory` + `spark.executor.memoryOverhead` + `spark.executor.pyspark.memory` + `spark.memory.offHeap.size`
 
 ```shell script
 helm repo add spark-operator https://kubeflow.github.io/spark-operator

--- a/docs/user_guide/workloads/run_spark.md
+++ b/docs/user_guide/workloads/run_spark.md
@@ -30,7 +30,7 @@ under the License.
 :::note
 Pre-requisites:
 - This tutorial assumes YuniKorn is [installed](../../get_started/get_started.md) under the namespace `yunikorn`
-- Use spark-operator version >= 2.0 to enable support for YuniKorn gang scheduling
+- Use spark-operator version >= 2.1.0 to enable support for YuniKorn gang scheduling
 :::
 
 ### Install YuniKorn


### PR DESCRIPTION
### What is this PR for?
once [spark-operator#2209](https://issues.apache.org/jira/browse/YUNIKORN-2919?filter=-4&jql=status%20in%20(Open%2C%20Reopened)%20AND%20assignee%20in%20(currentUser())%20order%20by%20created%20DESC#2209)(https://github.com/kubeflow/spark-operator/pull/2209) merged and released, it would be `memory + memoryOverhead + spark.executor.pyspark.memory + spark.memory.offHeap.size`


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-2919

### How should this be tested?

### Screenshots (if appropriate)

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
