### PR TITLE
[Yunicorn-2773]  Removal of default queue configuration

### DIFF
--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -1178,7 +1178,7 @@ service.operatorPlugins: "general"
   
 #### admissionController.filtering.defaultQueue
 
-**_DEPRECATED in 1.6.0:_** No replacement
+**_DEPRECATED in 1.6.0:_** This setting is deprecated. To configure a desire queue name, use the [Fixed Rule](placement_rules/#fixed-rule) placement rule instead.
 
 Controlls what will be the default queue name for the application.
 

--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -552,7 +552,6 @@ data:
   admissionController.filtering.labelNamespaces: ""
   admissionController.filtering.noLabelNamespaces: ""
   admissionController.filtering.generateUniqueAppId: "false"
-  admissionController.filtering.defaultQueue: "root.default"
   admissionController.accessControl.bypassAuth: "false"
   admissionController.accessControl.trustControllers: "true"
   admissionController.accessControl.systemUsers: "^system:serviceaccount:kube-system:"
@@ -1005,34 +1004,6 @@ Example:
 admissionController.filtering.generateUniqueAppId: "true"
 ```
 
-#### admissionController.filtering.defaultQueue
-Controlls what will be the default queue name for the application.
-
-If the application does not define a queue name during app submission, admission controller will add a default queue name to the pod labels. `root.default` queue name will be added to the pod labels if this property is not set.
-
-In case, the default queue name needs to be updated to something other than `root.default`,  `admissionController.filtering.defaultQueue` can be set with the desired queue name.
-
-Example:
-```yaml
-# Change default queue to root.mydefault
-admissionController.filtering.defaultQueue: "root.mydefault"
-```
-
-**_NOTE :_**
-The queue name needs to be a fully qualified queue name.
-
-For certain use-cases, there may be a need to skip adding a default queue name to the pod labels. In such cases, `admissionController.filtering.defaultQueue` can be set to empty string.
-
-Adding default queue name should be avoided when `provided` rule is used in conjunction with other placement rules and `provided` rule is higher in the hierarchy. If default queue label is added whenever there is no queue name specified, all the apps will be placed via `provided` rule and the other rules after that will never be executed.
-
-Default: `root.default`
-
-Example:
-```yaml
-# Skip adding default queue name
-admissionController.filtering.defaultQueue: ""
-```
-
 ### Admission controller ACL settings
 
 #### admissionController.accessControl.bypassAuth
@@ -1204,3 +1175,34 @@ service.operatorPlugins: "general"
     - shim.scheduler
     - shim.scheduler.plugin
     - shim.utils
+  
+#### admissionController.filtering.defaultQueue
+
+**_DEPRECATED in 1.6.0:_** No replacement
+
+Controlls what will be the default queue name for the application.
+
+If the application does not define a queue name during app submission, admission controller will add a default queue name to the pod labels. `root.default` queue name will be added to the pod labels if this property is not set.
+
+In case, the default queue name needs to be updated to something other than `root.default`,  `admissionController.filtering.defaultQueue` can be set with the desired queue name.
+
+Example:
+```yaml
+# Change default queue to root.mydefault
+admissionController.filtering.defaultQueue: "root.mydefault"
+```
+
+**_NOTE :_**
+The queue name needs to be a fully qualified queue name.
+
+For certain use-cases, there may be a need to skip adding a default queue name to the pod labels. In such cases, `admissionController.filtering.defaultQueue` can be set to empty string.
+
+Adding default queue name should be avoided when `provided` rule is used in conjunction with other placement rules and `provided` rule is higher in the hierarchy. If default queue label is added whenever there is no queue name specified, all the apps will be placed via `provided` rule and the other rules after that will never be executed.
+
+Default: `root.default`
+
+Example:
+```yaml
+# Skip adding default queue name
+admissionController.filtering.defaultQueue: ""
+```

--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -1121,6 +1121,37 @@ Example:
 service.operatorPlugins: "general"
 ```
 
+#### admissionController.filtering.defaultQueue
+
+**_DEPRECATED in 1.6.0:_** This setting is deprecated. To configure a desire queue name, use the [Fixed Rule](placement_rules/#fixed-rule) placement rule instead.
+
+Controlls what will be the default queue name for the application.
+
+If the application does not define a queue name during app submission, admission controller will add a default queue name to the pod labels. `root.default` queue name will be added to the pod labels if this property is not set.
+
+In case, the default queue name needs to be updated to something other than `root.default`,  `admissionController.filtering.defaultQueue` can be set with the desired queue name.
+
+Example:
+```yaml
+# Change default queue to root.mydefault
+admissionController.filtering.defaultQueue: "root.mydefault"
+```
+
+**_NOTE :_**
+The queue name needs to be a fully qualified queue name.
+
+For certain use-cases, there may be a need to skip adding a default queue name to the pod labels. In such cases, `admissionController.filtering.defaultQueue` can be set to empty string.
+
+Adding default queue name should be avoided when `provided` rule is used in conjunction with other placement rules and `provided` rule is higher in the hierarchy. If default queue label is added whenever there is no queue name specified, all the apps will be placed via `provided` rule and the other rules after that will never be executed.
+
+Default: `root.default`
+
+Example:
+```yaml
+# Skip adding default queue name
+admissionController.filtering.defaultQueue: ""
+```
+
 [^1]: Available log subsystem values:
     - admission
     - admission.client
@@ -1175,34 +1206,3 @@ service.operatorPlugins: "general"
     - shim.scheduler
     - shim.scheduler.plugin
     - shim.utils
-  
-#### admissionController.filtering.defaultQueue
-
-**_DEPRECATED in 1.6.0:_** This setting is deprecated. To configure a desire queue name, use the [Fixed Rule](placement_rules/#fixed-rule) placement rule instead.
-
-Controlls what will be the default queue name for the application.
-
-If the application does not define a queue name during app submission, admission controller will add a default queue name to the pod labels. `root.default` queue name will be added to the pod labels if this property is not set.
-
-In case, the default queue name needs to be updated to something other than `root.default`,  `admissionController.filtering.defaultQueue` can be set with the desired queue name.
-
-Example:
-```yaml
-# Change default queue to root.mydefault
-admissionController.filtering.defaultQueue: "root.mydefault"
-```
-
-**_NOTE :_**
-The queue name needs to be a fully qualified queue name.
-
-For certain use-cases, there may be a need to skip adding a default queue name to the pod labels. In such cases, `admissionController.filtering.defaultQueue` can be set to empty string.
-
-Adding default queue name should be avoided when `provided` rule is used in conjunction with other placement rules and `provided` rule is higher in the hierarchy. If default queue label is added whenever there is no queue name specified, all the apps will be placed via `provided` rule and the other rules after that will never be executed.
-
-Default: `root.default`
-
-Example:
-```yaml
-# Skip adding default queue name
-admissionController.filtering.defaultQueue: ""
-```

--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -1205,3 +1205,4 @@ admissionController.filtering.defaultQueue: ""
     - shim.rmcallback
     - shim.scheduler
     - shim.scheduler.plugin
+    - shim.utils

--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -1205,4 +1205,3 @@ admissionController.filtering.defaultQueue: ""
     - shim.rmcallback
     - shim.scheduler
     - shim.scheduler.plugin
-    - shim.utils


### PR DESCRIPTION
### What is this PR for?
According to https://issues.apache.org/jira/browse/YUNIKORN-2711 and https://issues.apache.org/jira/browse/YUNIKORN-2703, user cannot config default queue name through admissionController.filtering.defaultQueue or other configuration anymore. Apps will be placed in 'root.default' if no rule is provided. 


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/projects/YUNIKORN/issues/YUNIKORN-2773

### How should this be tested?

### Screenshots (if appropriate)
Move this to the ‘Deprecated Settings’ section and add a link directing users to the ‘App Placement Rules’ page for guidance on configuring the desired queue name with placement rules.
**new added Deprecated Settings**
![Screenshot 68](https://github.com/user-attachments/assets/3106cda8-b20e-4734-ae54-3949fa20feff)
**Fixed Rule**
<img width="1084" alt="image" src="https://github.com/user-attachments/assets/774824c7-e7d1-4ac4-ad53-37da86a73315" />

### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
