### PR TITLE
[YUNIKORN-3099] Update doc for new-added metrics

### DIFF
--- a/docs/performance/metrics.md
+++ b/docs/performance/metrics.md
@@ -46,6 +46,9 @@ all metrics are declared in `yunikorn` namespace.
 | sortingLatency        | Histogram    | Latency of all nodes sorting, in milliseconds.                                                                   |
 | tryNodeLatency        | Histogram    | Latency of node condition checks for container allocations, such as placement constraints, in milliseconds.      |
 | tryPreemptionLatency  | Histogram    | Latency of preemption condition checks for container allocations, in milliseconds.                               |
+| schedulingCycle       | Histogram    | Total time for a full scheduling cycle, in milliseconds.                                                         |
+| tryNodeEvaluation     | Histogram    | Total time for a pod to find a proper node, in milliseconds.                                                     |
+
 
 ###    Queue Metrics
 


### PR DESCRIPTION
### What is this PR for?
Add two prometheus consumable metrics
- schedulingCycle - Total time for a full scheduling
- tryNodeEvaluation - Total time for a pod to find a proper node

This is a pure document change on behalf of metric implementation at here: https://github.com/apache/yunikorn-core/pull/1017


### What type of PR is it?
* [ ] - Bug Fix
* [ ] - Improvement
* [ ] - Feature
* [x] - Documentation
* [ ] - Hot Fix
* [ ] - Refactoring

### Todos
* [ ] - Task

### What is the Jira issue?
https://issues.apache.org/jira/browse/YUNIKORN-3099

### How should this be tested?

### Screenshots (if appropriate)
![Screenshot 16](https://github.com/user-attachments/assets/c3e1055d-d977-4982-a124-e81f09f263fb)


### Questions:
* [ ] - The licenses files need update.
* [ ] - There is breaking changes for older versions.
* [ ] - It needs documentation.
