### PR TITLE
[YUNIKORN-3234] Remove node-utilization redirect from routes

### DIFF
--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -1495,52 +1495,6 @@ Node details include host and rack name, capacity, resources, utilization, and a
 
 **Code** : `500 Internal Server Error`
 
-### Node utilization
-
-Show how every node is distributed with regard to dominant resource utilization.
-
-**Status** : Deprecated since v1.5.0 and will be removed in the next major release. Replaced with `/ws/v1/scheduler/node-utilizations`.
-
-**URL** : `/ws/v1/scheduler/node-utilization`
-
-**Method** : `GET`
-
-**Auth required** : NO
-
-#### Success response
-
-**Code** : `200 OK`
-
-**Content examples**
-
-```json
-{
-    "type": "vcore",
-    "utilization": [
-      {
-        "bucketName": "0-10%",
-        "numOfNodes": 1,
-        "nodeNames": [
-          "aethergpu"
-        ]
-      },
-      {
-        "bucketName": "10-20%",
-        "numOfNodes": 2,
-        "nodeNames": [
-            "primary-node",
-            "second-node"
-        ]
-      },
-      ...  
-    ]
-}
-```
-
-#### Error response
-
-**Code** : `500 Internal Server Error`
-
 
 ### Node utilizations
 


### PR DESCRIPTION
### What is this PR for?
The deprecated "/ws/v1/scheduler/node-utilization" was replaced with "/ws/v1/scheduler/node-utilizations" as part of YuniKorn 1.5.

Removal of the code and redirect as part of YuniKorn 1.9.

### What type of PR is it?
* [X] - Documentation

### What is the Jira issue?
* [YUNIKORN-3234](https://issues.apache.org/jira/browse/YUNIKORN-3234)

### How should this be tested?
NA, test that used the endpoint have been removed

### Screenshots (if appropriate)
NA

### Questions:
* [X] - There is breaking changes for older versions: removal of API
* [X] - It needs documentation.