### PR TITLE
[YUNIKORN-3297] Update license check

### DIFF
--- a/check_license.sh
+++ b/check_license.sh
@@ -22,9 +22,9 @@ OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 echo "checking license headers:"
 # run different finds on mac vs linux
 if [ "${OS}" = "darwin" ]; then
-  find -E . ! -path "./.git*" ! -path "./.docusaurus*" ! -path "./node_modules*" ! -path ./pnpm-lock.yaml -regex ".*(Dockerfile|\.(js|sh|md|conf|yaml|yml|html|css))" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES
+  find -E . ! -path "./build*" ! -path "./.git*" ! -path "./.docusaurus*" ! -path "./node_modules*" ! -path "./pnpm-*.yaml" -regex ".*(Dockerfile|\.(js|sh|md|conf|yaml|yml|html|css))" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES
 else
-  find . ! -path "./.git*" ! -path "./.docusaurus*" ! -path "./node_modules*" ! -path ./pnpm-lock.yaml -regex ".*\(Dockerfile\|\.\(js\|sh\|md\|conf\|yaml\|yml\|html\|css\)\)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES
+  find . ! -path "./build*" ! -path "./.git*" ! -path "./.docusaurus*" ! -path "./node_modules*" ! -path "./pnpm-*.yaml" -regex ".*\(Dockerfile\|\.\(js\|sh\|md\|conf\|yaml\|yml\|html\|css\)\)" -exec grep -L "Licensed to the Apache Software Foundation" {} \; > LICRES
 fi
 # any file mentioned in the output is missing the license
 if [ -s LICRES ]; then


### PR DESCRIPTION
### What is this PR for?
Remove pnpm-workspace.yaml from the files checked. Update regexp to ignore ./build and all the artifacts below it as it is the website production build which does not have license headers in the js files.

### What type of PR is it?
* [X] - Bug Fix

### What is the Jira issue?
* Jira issue: [YUNIKORN-3297](https://issues.apache.org/jira/browse/YUNIKORN-3297)

### How should this be tested?
./check_license.sh should pass in CI and local builds even after a doing a production build on the local machine