### PR TITLE
[YUNIKORN-3314] Update logging subsystem values

### DIFF
--- a/docs/user_guide/service_config.md
+++ b/docs/user_guide/service_config.md
@@ -827,7 +827,7 @@ Sets the verbosity that YuniKorn subsystem will log at.
 Yunikorn allows fine-grained logging configuration in a hierarchical manner. For example,
 setting an entry for `log.core.level` will configure all loggers that start with `core.`
 (including `core.scheduler`, etc.) unless a more specific configuration is present.
-Each subsystem[^1] has its log level.
+Each subsystem allows configuring a separate log level. The list of subsystems is defined [here](#log-subsystem-values) 
 
 A change to this setting will be picked up without a restart of YuniKorn. The available
 values can be numeric or textual:
@@ -846,10 +846,11 @@ Example:
 
 The `log.level` is the default log level for all loggers.
 
+Example configuration with a log level set to INFO except for the admission controller (DEBUG), and the core configuration code (WARN). 
 ```yaml
 log.level: "INFO"
 log.admission.level: "DEBUG"
-log.core.config.level: "INFO"
+log.core.config.level: "WARN"
 ```
 
 ### Kubernetes settings
@@ -1145,14 +1146,19 @@ Example:
 admissionController.filtering.defaultQueue: ""
 ```
 
-[^1]: Available log subsystem values:
+### Log subsystem values
+
+#### Admission controller
     - admission
     - admission.client
     - admission.conf
     - admission.utils
     - admission.webhook
+
+#### Scheduler core
     - core
     - core.config
+    - core.diagnostics
     - core.entrypoint
     - core.events
     - core.metrics
@@ -1169,19 +1175,20 @@ admissionController.filtering.defaultQueue: ""
     - core.scheduler.fsm
     - core.scheduler.health
     - core.scheduler.node
+    - core.scheduler.nodesusage
     - core.scheduler.partition
     - core.scheduler.preemption
+    - core.scheduler.preemption.quotachange
+    - core.scheduler.preemption.requirednode
     - core.scheduler.queue
     - core.scheduler.reservation
     - core.scheduler.ugm
     - core.security
     - core.utils
-    - deprecation
+
+#### Kubernetes shim
     - kubernetes
     - shim
-    - shim.appmgmt
-    - shim.appmgmt.general
-    - shim.appmgmt.sparkoperator
     - shim.cache.application
     - shim.cache.external
     - shim.cache.node
@@ -1193,9 +1200,14 @@ admissionController.filtering.defaultQueue: ""
     - shim.dispatcher
     - shim.framework
     - shim.fsm
+    - shim.placeholder.config
     - shim.predicates
     - shim.resources
     - shim.rmcallback
     - shim.scheduler
-    - shim.scheduler.plugin
     - shim.utils
+
+#### Special purpose logger
+Supported by the admission controller, core and kubernetes shim
+
+    - deprecation


### PR DESCRIPTION
### Description
Update the supported log subsystem values in the documentation. Added:
* deprecation (now supported in K8shim also)
* core.diagnostics (1.5 ?)
* core.scheduler.nodesusage (1.5)
* core.scheduler.preemption.quotachange (1.8)
* core.scheduler.preemption.requirednode (1.8)
* shim.placeholder.config (1.9)

Removed:
* shim.appmgmt (1.6 ?)
* shim.appmgmt.general (1.6 ?)
* shim.appmgmt.sparkoperator (1.7)
* shim.scheduler.plugin (1.9)

### Type of change
- [X] Documentation

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3314

- [X] I have created a Jira issue for this pull request
- [X] The Jira ID is part of the title of this pull request

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [ ] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How Has This Been Tested?
- [X] `check_license.sh` returned an "all OK" result
- [X] `local_build.sh run` generated a usable website

### Screenshots or other details

