### PR TITLE
[YUNIKORN-3310] Document yunikorn_queue_app_total metric

### DIFF
--- a/docs/metrics/queue.md
+++ b/docs/metrics/queue.md
@@ -45,6 +45,29 @@ yunikorn_queue_app{queue="root.default",state="accepted"} 3
 yunikorn_queue_app{queue="root.default",state="running"} 3
 ```
 
+## Application Total
+
+The `yunikorn_queue_app_total` metric, introduced in version `1.10.0`, tracks the cumulative number of applications that reached a terminal state in each queue. Unlike the `yunikorn_queue_app` gauge, this counter is monotonically increasing and persists across queue removal and recreation.
+
+### Metric details
+
+**Metric Type**: `counter`
+
+**Namespace**: `yunikorn`
+
+**Labels**:
+- `queue`: the name of the queue (e.g., "root.default")
+- `state`: the terminal state of the application
+  - `completed`, `failed`, `rejected`
+
+**TYPE**: `yunikorn_queue_app_total`
+
+```json
+yunikorn_queue_app_total{queue="root.default",state="completed"} 15
+yunikorn_queue_app_total{queue="root.default",state="failed"} 2
+yunikorn_queue_app_total{queue="root.default",state="rejected"} 1
+```
+
 ## Resource
 The `yunikorn_queue_resource` metric, introduced in version `1.5.0`, tracks the resource states in each queue using labels.
 


### PR DESCRIPTION
### Description
Add documentation for the new `yunikorn_queue_app_total` counter metric that tracks cumulative terminal application states (completed, failed, rejected) per queue.

This is the documentation follow-up for the code change merged in apache/yunikorn-core#1097.

### Type of change
- [x] Documentation

<img width="762" height="712" alt="image" src="https://github.com/user-attachments/assets/50cf1b0b-7a8a-4f27-82ca-85743676c984" />


### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3310

- [x] I have created a Jira issue for this pull request.
- [x] The Jira ID is part of the title of this pull request.

### AI Tooling
- [x] The PR includes the phrase "Generated by Claude Code", where Claude Code is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Generated by Claude Code