### PR TITLE
[YUNIKORN-3247] Update troubleshooting statedump collection

### DIFF
--- a/docs/user_guide/troubleshooting.md
+++ b/docs/user_guide/troubleshooting.md
@@ -153,12 +153,8 @@ There are a few ways to obtain the full state dump.
 ### 1. Scheduler URL
 
 STEPS:
-* Port forwarding for the REST service on the standard port can be turned on via:
-  ```shell script
-  kubectl port-forward svc/yunikorn-service 9080:9080 -n yunikorn
-  ```
-* Open the debug endpoint URL in your browser:
-  `http://localhost:9080/debug/fullstatedump`
+* Enable port forwarding to access the scheduler web service (see [Access to the web UI](https://yunikorn.apache.org/docs/developer_guide/deployment#access-to-the-web-ui)).
+* Open the debug endpoint in your browser: `http://localhost:9080/debug/fullstatedump`
 * Press Enter
 
 That displays and provides an easy user experience to view live full state dump.

--- a/docs/user_guide/troubleshooting.md
+++ b/docs/user_guide/troubleshooting.md
@@ -146,13 +146,19 @@ A Yunikorn state dump contains the every state object for every process which ge
 
 The state dump is a valuable resource that Yunikorn offers for use while troubleshooting.
 
+Since the debug endpoints are not proxied by the web UI server, you need to access the scheduler web service directly.
+
 There are a few ways to obtain the full state dump.
 
 ### 1. Scheduler URL
 
 STEPS:
-* Open the Scheduler URL in your browser window/tab and edit the URL as follows:
-* Replace `/#/dashboard` with `/ws/v1/fullstatedump`, (For example, `http://localhost:9889/ws/v1/fullstatedump`)
+* Port forwarding for the REST service on the standard port can be turned on via:
+  ```shell script
+  kubectl port-forward svc/yunikorn-service 9080:9080 -n yunikorn
+  ```
+* Open the debug endpoint URL in your browser:
+  `http://localhost:9080/debug/fullstatedump`
 * Press Enter
 
 That displays and provides an easy user experience to view live full state dump.
@@ -161,7 +167,7 @@ That displays and provides an easy user experience to view live full state dump.
 
 With the below scheduler REST API returns information about full state dump used by the YuniKorn Scheduler.
 
-`curl -X 'GET' http://localhost:9889/debug/fullstatedump -H 'accept: application/json'`
+`curl -X 'GET' http://localhost:9080/debug/fullstatedump -H 'accept: application/json'`
 
 For more details around the content of the state dump, please refer to the documentation on [retrieve-full-state-dump](api/system.md#retrieve-state-dump)
 


### PR DESCRIPTION
Update the troubleshooting documentation for the collection of the statedump. Replace the deprecated /ws/v1/fullstatedump endpoint and port 9889 with the correct /debug/fullstatedump endpoint and port 9080, which is hosted by the core scheduler web service directly. Add port-forwarding instructions for port 9080.


### Description
Short description of this pull request, can be as simple as the commit message used.
First time contributing? Check out the contributing guide: https://yunikorn.apache.org/community/how_to_contribute



### Type of change
Please delete options that are not relevant.

- [X] Documentation
- [ ] Improvement
- [ ] Feature
- [ ] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3247

- [X] I have created a Jira issue for this pull request
- [X] The Jira ID is part of the title of this pull request

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How Has This Been Tested?
- [X] `check_license.sh` returned an "all OK" result
- [X] `local_build.sh run` generated a usable website

### Screenshots or other details
NA
