### PR TITLE
[YUNIKORN-3216] Document unschedulable backoff settings and REST API …

### DIFF
--- a/docs/api/scheduler.md
+++ b/docs/api/scheduler.md
@@ -565,7 +565,8 @@ In the example below there are three allocations belonging to two applications, 
             }
         ],
         "hasReserved": false,
-        "reservations": []
+        "reservations": [],
+        "backoffDeadline": 1648754032081234567
     },
     {
         "applicationID": "application-0002",

--- a/docs/user_guide/queue_config.md
+++ b/docs/user_guide/queue_config.md
@@ -430,6 +430,22 @@ The property can be set on any queue. The default value will not trigger quota p
 The first quota configuration change is considered the trigger time. The starting time is the trigger time plus the delay. Consecutive quota changes will not affect the trigger time.
 Delay changes are applied to the starting time as a delta compared to the original delay value.
 
+#### `application.unschedasks.backoff`
+
+Supported values: any non-negative 64-bit integer
+
+Default value: `0`
+
+Sets the threshold for the number of unschedulable requests to check before triggering backoff for an application in the queue. When an application has too many unschedulable tasks, repeatedly evaluating them can impact scheduling throughput. Setting this property to a value greater than `0` enables backoff. The default value of `0` disables backoff.
+
+#### `application.unschedasks.backoff.delay`
+
+Supported values: any positive [Golang duration string](https://pkg.go.dev/time#ParseDuration)
+
+Default value: `30s`
+
+Sets the backoff delay duration when unschedulable task backoff is triggered for an application (via `application.unschedasks.backoff`). During this backoff period, further scheduling attempts for the application's unschedulable tasks are paused.
+
 ### Resources
 The resources entry for the queue can set the _guaranteed_ and or _maximum_ resources for a queue.
 Resource limits are checked recursively.


### PR DESCRIPTION
### Description
[YUNIKORN-3216] Document unschedulable backoff settings and REST API updates
- Document queue configuration properties 'application.unschedasks.backoff' and 'application.unschedasks.backoff.delay' in docs/user_guide/queue_config.md.
- Update REST API documentation in docs/api/scheduler.md:
  * Add 'backoffDeadline' field (UnixNano int64 per YUNIKORN-3326) to Application REST API json response format.

### Type of change
Please delete options that are not relevant.

- [X] Documentation
- [ ] Improvement
- [ ] Feature
- [ ] Bug Fix

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3216

- [ ] I have created a Jira issue for this pull request
- [X] The Jira ID is part of the title of this pull request

### AI Tooling
If an AI tool was used:
- [X] The PR includes the phrase "Generated by  Antigravity IDE", where Antigravity IDE is the name of the AI tool used.
- [X] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How Has This Been Tested?
- [X] `check_license.sh` returned an "all OK" result
- [X] `local_build.sh run` generated a usable website

### Screenshots or other details
Note for testing:
The backoffDeadline REST API field is documented using the int64 (UnixNano) format per [YUNIKORN-3326](https://issues.apache.org/jira/browse/YUNIKORN-3326). When testing live, please use a yunikorn-core build that includes YUNIKORN-3326; otherwise, older releases (e.g., 1.8.0) will output an RFC3339 string instead of an int64 integer timestamp.
