### PR TITLE
[YUNIKORN-3248] Improve quota preemption documentation

### DIFF
--- a/docs/user_guide/quota_preemption.md
+++ b/docs/user_guide/quota_preemption.md
@@ -53,16 +53,24 @@ When quota preemption is turned on at the partition level quota changes could tr
 
 ## Queue configuration
 
-With the global configuration is turned on each queue must be configured to opt in to quota preemption. A queue can opt in by setting the _quota.preemption.delay_ property on the queue.
+With the global configuration turned on, each queue must be configured to opt in to quota preemption. A queue can opt in by setting the _quota.preemption.delay_ property on the queue.
 
 ```yaml
 queues:
   - name: default
     properties:
-      quota.preemption.delay: <delay string>
+      quota.preemption.delay: <delay value>
 ```
 
-The delay when not specified defaults to 0. A delay value explicitly set to 0 will prevent the quota change of the queue from triggering preemption.
+The delay value must be specified in Go [time.Duration](https://pkg.go.dev/time#ParseDuration) format. Valid units are `s` (seconds), `m` (minutes), and `h` (hours). Units can be combined.
+
+Examples of valid delay values:
+- `15s` — 15 seconds
+- `5m` — 5 minutes
+- `1h30m` — 1 hour and 30 minutes
+- `2h` — 2 hours
+
+The delay when not specified defaults to `0`. A delay value explicitly set to `0` will prevent the quota change of the queue from triggering preemption.
 Any non-zero value for the delay will be added to the time the change of the quota was applied to the queue. That timestamp defines the trigger point for quota preemption.
 Quota preemption will only be triggered if the queue at the point in time of the change is above the new quota.
 The standard scheduling quota enforcement will immediately enforce the new quota in all other cases and no further preemption actions are needed.
@@ -103,6 +111,51 @@ Dynamic queues do not support quota preemption.
 The current configuration does not support inheritance of the _quota.preemption.delay_ value.
 [YUNIKORN-3208](https://issues.apache.org/jira/browse/YUNIKORN-3208) has been logged to support that functionality.
 :::
+
+## Triggering preconditions
+
+Quota preemption is triggered when **all** of the following conditions are met:
+
+1. Quota preemption is enabled at the partition level (`quotapreemptionenabled: true`)
+2. The queue has a non-zero `quota.preemption.delay` configured
+3. The queue is a managed queue (not dynamically created)
+4. The queue's allocated resources exceed its configured max resources
+5. No quota preemption is currently running for that queue
+6. The configured delay has elapsed since the trigger event
+
+If the queue usage drops below the max resources before the delay expires, the preemption is cancelled and the tracking state is cleared.
+
+:::note
+Quota preemption does not check for pending pods. It triggers based solely on allocated resources exceeding the max quota. This means preemption can occur even if no workloads are waiting for resources.
+:::
+
+## Configuration change scenarios
+
+The following table describes when and how quota preemption is triggered for various configuration changes:
+
+| Scenario | Behavior |
+| --- | --- |
+| Max resources decreased | Start time is set to `now + delay`. Preemption will trigger after the delay if usage still exceeds the new max. |
+| Delay value changed | The start time is adjusted by the difference: `startTime += (newDelay - oldDelay)`. |
+| New allocation pushes queue over max | Start time is set to `now + delay`. This can occur when a running allocation is added to the queue. |
+| Consecutive quota decreases | The earliest start time is preserved. Subsequent decreases do not reset the timer. |
+| Quota increased back (usage < new max) | Start time is cleared. Preemption is cancelled. |
+| Max resources removed entirely | Start time is cleared. No quota means no limit to enforce. |
+
+:::caution
+If preemption has already been triggered and is in progress, a subsequent quota increase or removal cannot stop the running preemption process. Only future preemption cycles are affected.
+:::
+
+## Restart behavior
+
+The quota preemption start time is held in memory and is **not** persisted to any external store. When the YuniKorn scheduler restarts:
+
+1. The preemption start time is lost.
+2. During recovery, allocations are restored via the resource manager (shim). Each allocation increments the queue's allocated resources.
+3. If, after recovery, a queue's usage exceeds its max resources and a non-zero delay is configured, a **new** start time is set to `now + delay`.
+4. Preemption will only trigger after the full delay has elapsed from the restart time.
+
+This means that a restart effectively resets the preemption timer. Preemption will not fire immediately after a restart even if the delay had already elapsed before the restart.
 
 ## Recommendations
 


### PR DESCRIPTION
### Description
Improve the quota preemption user guide with missing details identified in YUNIKORN-3248:
- Clarify that `quota.preemption.delay` uses Go `time.Duration` format (e.g. `15s`, `5m`, `1h30m`)
- Add "Triggering preconditions" section listing all 6 conditions required for quota preemption
- Add "Configuration change scenarios" table covering max decrease, delay change, consecutive decreases, quota increase back, and max removal
- Add "Restart behavior" section explaining that the preemption timer is in-memory only and resets on restart

**Note on pending pods (JIRA item #3):** The JIRA suggests documenting that quota preemption only triggers when pending pods exist. After reviewing the code (`tryAcquirePreemption()` in `queue.go`, `internalQuotaPreemption()` in `scheduler.go`, and `quota_preemptor.go`), there is no pending pods check in the quota preemption flow. It triggers solely based on `allocatedResource > maxResource`. This is documented as a note in the "Triggering preconditions" section.

**Observation:** `pnpm build` reports 50 pre-existing broken anchors across versioned docs (mostly 1.0.01.3.0), unrelated to this change. Would it be worth filing a separate issue to clean those up?

Generated by GitHub Copilot (Claude Opus 4.6)

### Type of change
- [x] Documentation
- [x] Improvement

### Jira issue
Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3248

- [x] I have created a Jira issue for this pull request
- [x] The Jira ID is part of the title of this pull request

### AI Tooling
- [x] The PR includes the phrase "Generated by GitHub Copilot (Claude Opus 4.6)"
- [x] My use of AI contributions follows the ASF legal policy.

### How Has This Been Tested?
- [x] `check_license.sh` returned an "all OK" result
- [x] `local_build.sh run` generated a usable website

### Screenshots or other details
N/A