### PR TITLE
[YUNIKORN-3348] Fix and extend the concurrency documentation

### DIFF
--- a/docs/design/cache_removal.md
+++ b/docs/design/cache_removal.md
@@ -423,7 +423,7 @@ A state change is thus immediate and this should prevent an issue like [YUNIKORN
 ### Direction of lock 
 It is possible to acquire another lock while holding a lock, but we need to make sure that we do not allow: 
 - Holding A.lock and acquire B's lock. 
-- Holding B.lock and acquire B's lock. 
+- Holding B.lock and acquire A's lock. 
 
 The current code in the scheduler takes a lock as late as possible and only for the time period needed.
 Some actions are not locked on the scheduler side just on the cache side as each object has its own lock.
@@ -453,4 +453,8 @@ The partition should be locked while retrieving for instance the node that needs
 
 This approach fits in with the current locking approach and will keep the locking changes to a minimum.
 Testing, specifically end-to-end testing, should catch these deadlocks. 
-There are no known tools that could be used to detect or describe lock order.
+
+Since this design was written, runtime detection has been added.
+The `pkg/locking` package wraps [go-deadlock](https://github.com/sasha-s/go-deadlock) and provides both lock order detection and lock wait timeout detection for all locks that use it.
+It is disabled by default and is turned on using the environment variables described in [deadlock detection](../user_guide/troubleshooting.md#deadlock-detection).
+The unit test run, `make test`, enables it in both the core and the k8shim.

--- a/docs/developer_guide/build.md
+++ b/docs/developer_guide/build.md
@@ -163,6 +163,12 @@ To make sure that the local changes will not break other parts of the
 build you should run:
 - A full build `make` (build target depends on the repository)
 - A full unit test run `make test`
+  This runs the tests with the race detector (`-race`) and with deadlock detection
+  enabled: `DEADLOCK_DETECTION_ENABLED=true`, `DEADLOCK_TIMEOUT_SECONDS=10` and
+  `DEADLOCK_EXIT=true`. A run that ends with a `POTENTIAL DEADLOCK` report and a
+  non-zero exit code is a detected lock problem, not a flaky test. See
+  [deadlock detection](../user_guide/troubleshooting.md#deadlock-detection) for
+  the settings and how to read the report.
 - For diagnosing flaky tests, which are challenging due to their infrequent failures, use a looping command to repeatedly run the test. For instance, to diagnose `TestNoFillWithoutEventPluginRegistered` in `yunikorn-core/pkg/events/event_publisher_test.go`, you can use the following command:
 
   ```sh

--- a/docs/user_guide/troubleshooting.md
+++ b/docs/user_guide/troubleshooting.md
@@ -167,6 +167,51 @@ With the below scheduler REST API returns information about full state dump used
 
 For more details around the content of the state dump, please refer to the documentation on [retrieve-full-state-dump](api/system.md#retrieve-state-dump)
 
+## Deadlock detection
+
+If the scheduler stops making progress but the process is still running and responding to the
+REST API, a lock problem is one possible cause. YuniKorn can detect this at runtime.
+
+All locks in the scheduler core and the Kubernetes shim are created through the `pkg/locking`
+package, which wraps [go-deadlock](https://github.com/sasha-s/go-deadlock). The shim delegates
+its configuration to the core, so a single set of settings covers both. Detection is **disabled
+by default** and is turned on with environment variables on the scheduler container:
+
+| Variable | Default | Effect |
+|---|---|---|
+| `DEADLOCK_DETECTION_ENABLED` | `false` | Master switch. go-deadlock is always compiled in, this only enables it. |
+| `DEADLOCK_TIMEOUT_SECONDS` | `60` | How long a goroutine may wait for a lock before a potential deadlock is reported. |
+| `DEADLOCK_EXIT` | `false` | Terminate the process with exit code 1 when a potential deadlock is detected. |
+| `DEADLOCK_DISABLE_LOCK_ORDER` | `false` | Disable lock order (ABBA) detection and keep only the wait timeout check. |
+
+Two independent checks are performed. The **wait timeout** check reports a goroutine that has
+been waiting for a single lock for longer than `DEADLOCK_TIMEOUT_SECONDS`. The **lock order**
+check reports two locks that have been acquired in opposite orders by different goroutines,
+which can deadlock even if it has not happened yet.
+
+Reports are written to the log under the `core.diagnostics` subsystem at `ERROR` level, and
+begin with `POTENTIAL DEADLOCK`. Each report names the goroutine holding the lock and the
+goroutine waiting for it, with a stack trace for both.
+
+Whether detection is currently active can be read back from the scheduler:
+
+```shell script
+curl -X 'GET' http://localhost:9080/ws/v1/config -H 'accept: application/json'
+```
+
+The response includes `DeadlockDetectionEnabled` and `DeadlockTimeoutSeconds`.
+
+:::note
+`DEADLOCK_EXIT=true` will terminate a running scheduler as soon as a potential deadlock is
+seen. That is useful when reproducing a problem, because it captures the state at the point of
+detection instead of leaving a hung process, but consider the effect on a production cluster
+before enabling it there.
+:::
+
+Detection is enabled for unit tests in both repositories. The `make test` target sets
+`DEADLOCK_DETECTION_ENABLED=true`, `DEADLOCK_TIMEOUT_SECONDS=10` and `DEADLOCK_EXIT=true`, so a
+test run that ends with a `POTENTIAL DEADLOCK` report has found a real lock problem.
+
 ## Restart the scheduler
 
 :::note


### PR DESCRIPTION
### Description

The only statement of the scheduler's lock ordering rule anywhere on the site was malformed, and the text around it predates the deadlock detection feature added in YUNIKORN-2539.

- **`docs/design/cache_removal.md`** — correct the lock direction rule. The second bullet read *"Holding B.lock and acquire B's lock"*, which is a tautology, so the rule as published stated nothing. It should be *"acquire A's lock"*. This is the only lock-ordering statement in the documentation.
- **`docs/design/cache_removal.md`** — replace *"There are no known tools that could be used to detect or describe lock order"* with a reference to `pkg/locking`. That has been inaccurate since YUNIKORN-2539 (commit `5758d7a`, 2024-04-05) added the package, which wraps [go-deadlock](https://github.com/sasha-s/go-deadlock) and performs exactly lock order and lock wait detection.
- **`docs/user_guide/troubleshooting.md`** — new "Deadlock detection" section documenting the four `DEADLOCK_*` environment variables, the two checks they control, where the report is logged (`core.diagnostics`, `ERROR`), and how to read the current setting back from `/ws/v1/config`.
- **`docs/developer_guide/build.md`** — state that `make test` runs with `-race` and deadlock detection enabled, so a run ending in `POTENTIAL DEADLOCK` is a real lock problem rather than a flaky test.

#### Two notes for reviewers

**Placement.** The Jira suggests `service_config.md` for the environment variables. I have put them in `troubleshooting.md` instead: `service_config.md` documents Helm values and ConfigMap keys, and these are neither — they are environment variables set on the container. `troubleshooting.md` already covers log retrieval, the state dump and restarting the scheduler, which is the context an operator is in when they need this. Happy to move it if you would prefer to keep all runtime settings together.

**Versioned docs.** This changes `docs/` only, matching recent documentation PRs (#563, #564, #565), so the corrections appear in the next release. The published 1.9.0 docs keep the garbled rule until then. Let me know if you would like the two `cache_removal.md` corrections backported to `versioned_docs/version-1.9.0/` as well — they are factual errors rather than new content, so there is an argument for it.

### Type of change

- [x] Documentation
- [x] Bug Fix

### Jira issue

Jira ID : https://issues.apache.org/jira/browse/YUNIKORN-3348

- [x] I have created a Jira issue for this pull request
- [x] The Jira ID is part of the title of this pull request

### AI Tooling

Generated by the Author with assistance from Claude Code.

- [x] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How Has This Been Tested?

- [x] `check_license.sh` returned an "all OK" result
- [ ] `local_build.sh run` generated a usable website

Instead of the Docker wrapper, the site was built directly with `pnpm install --frozen-lockfile && pnpm build`, which runs the same Docusaurus build. Result: `[SUCCESS] Generated static files in "build"`.

Checks performed on the generated output:

- The new `## Deadlock detection` heading produces the anchor `#deadlock-detection` in `build/docs/next/user_guide/troubleshooting/index.html`.
- Both new cross-document links resolve, appearing in the generated HTML as `href="/docs/next/user_guide/troubleshooting#deadlock-detection"` from `design/cache_removal` and `developer_guide/build`.
- The build reports pre-existing broken-anchor warnings elsewhere on the site; none of them are on the three pages touched here, and this change adds none.

### Screenshots or other details

Sources for the factual claims in the new documentation, so they can be checked:

- The four environment variables, their defaults and behaviour: `yunikorn-core/pkg/locking/locking.go`.
- The shim delegates its configuration to the core, so one set of settings covers both: `yunikorn-k8shim/pkg/locking/locking.go` calls into `corelocking` from its `init()`.
- Reports are logged under `core.diagnostics` at `ERROR` level: `printBufContents()` in the same core file.
- `/ws/v1/config` returns `DeadlockDetectionEnabled` and `DeadlockTimeoutSeconds`: `yunikorn-core/pkg/webservice/dao/config_info.go` and `handlers.go`.
- `make test` exports `DEADLOCK_DETECTION_ENABLED=true`, `DEADLOCK_TIMEOUT_SECONDS=10`, `DEADLOCK_EXIT=true` and runs with `-race` in both repositories: the `test` target in each `Makefile`.
