### PR TITLE
[YUNIKORN-3347] Document checksum fields in validate-conf REST response

### DIFF
--- a/docs/api/cluster.md
+++ b/docs/api/cluster.md
@@ -221,6 +221,8 @@ Regardless whether the configuration is allowed or not if the server was able to
 
 **Code** : `200 OK`
 
+The response always contains the `allowed` field. When the configuration is rejected the `reason` field describes why. When the configuration is allowed the response also contains the `checksum` calculated over the submitted configuration and `checksumMatch`, which is `true` when the checksum already present in the submitted configuration matched the calculated `checksum`.
+
 #### Allowed configuration
 
 Sending the following simple configuration yields an accept
@@ -239,7 +241,8 @@ Reponse
 ```json
 {
     "allowed": true,
-    "reason": ""
+    "checksum": "9F86D081884C7D659A2FEAA0C55AD015A3BF4F1B2B0B822CD15D6C15B0F00A08",
+    "checksumMatch": false
 }
 ```
 


### PR DESCRIPTION
### Description
Added the checksum and checksumMatch fields to the Configuration validation success response reference in the cluster REST API docs.



### Type of change
Please delete options that are not relevant.

- [x] Documentation
- [ ] Improvement
- [ ] Feature
- [ ] Bug Fix

### Jira issue
Jira ID : [YUNIKORN-3347](https://issues.apache.org/jira/browse/YUNIKORN-3347)

- [x] I have created a Jira issue for this pull request
- [x] The Jira ID is part of the title of this pull request

### AI Tooling
If an AI tool was used:
- [ ] The PR includes the phrase "Generated by \<tool>", where \<tool> is the name of the AI tool used.
- [x] My use of AI contributions follows the ASF legal policy.

Check https://www.apache.org/legal/generative-tooling.html for details.

### How Has This Been Tested?
- [ ] `check_license.sh` returned an "all OK" result
- [ ] `local_build.sh run` generated a usable website

### Screenshots or other details

